### PR TITLE
CHK-656 fix pa fiscal code template

### DIFF
--- a/src/templates/success/success.json
+++ b/src/templates/success/success.json
@@ -122,7 +122,7 @@
                 "properties": {
                   "type": {
                     "enum": ["codiceAvviso", "IUV"],
-                    "examples": ["codiceAvviso"]
+                    "examples": ["codiceAvviso","IUV"]
                   },
                   "value": {
                     "type": "string",

--- a/src/templates/success/success.json
+++ b/src/templates/success/success.json
@@ -126,7 +126,7 @@
                   },
                   "value": {
                     "type": "string",
-                    "examples": ["123456789012345678"]
+                    "examples": ["123456789012345678","RF865613749"]
                   }
                 }
               },
@@ -150,11 +150,11 @@
                 "properties": {
                   "name": {
                     "type": "string",
-                    "examples": ["Comune di Controguerra"]
+                    "examples": ["Comune di Controguerra","Comune di Milano"]
                   },
                   "taxCode": {
-                    "type": "integer",
-                    "examples": [82001760675]
+                    "type": "string",
+                    "examples": ["82001760675","01199250158"]
                   }
                 }
               },


### PR DESCRIPTION
Public Administration fiscal code is a 11 digit , so it shall be represented as string , not as integer.

#### List of Changes

change taxCode type from integer to string
add an examples for IUV type

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->


#### How Has This Been Tested?
running `yarn run generate:template-schema` create a valid json data named `success.ts`

#### Screenshots (if appropriate):
N/A
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)


#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

