### PR TITLE
fix(deploy): add release url into manual validation

### DIFF
--- a/.devops/azure-templates/chart-current-version.yml
+++ b/.devops/azure-templates/chart-current-version.yml
@@ -13,7 +13,7 @@ steps:
         CHART_FILE="helm/Chart.yaml"
         version=$(yq -r '.version' $CHART_FILE)
         appVersion=$(yq -r '.appVersion' $CHART_FILE)
-        trimmed_repo_url=$(echo $(Build.Repository.Uri) | | sed -e "s/\.git//g")
+        trimmed_repo_url=$(echo $(Build.Repository.Uri) | sed -e "s/\.git//g")
         release_url=$(echo $trimmed_repo_url/releases/tag/v$appVersion-RELEASE)
         echo "##vso[task.setvariable variable=version;isOutput=true]$version"
         echo "##vso[task.setvariable variable=appVersion;isOutput=true]$appVersion"

--- a/.devops/azure-templates/chart-current-version.yml
+++ b/.devops/azure-templates/chart-current-version.yml
@@ -1,0 +1,22 @@
+# Read the current chart version and output it 3 variables
+# -> 'chart_current_version.version' : the Chart version
+# -> 'chart_current_version.appVersion': the application version
+# -> 'chart_current_version.releaseUrl': the module release url formatted as https:://<<repo-url>>/releases/tag/v<<appVersion>>-RELEASE
+
+steps:
+  - task: Bash@3
+    name: chart_current_version
+    displayName: 'Read chart current version'
+    inputs:
+      targetType: "inline"
+      script: |
+        CHART_FILE="helm/Chart.yaml"
+        version=$(yq -r '.version' $CHART_FILE)
+        appVersion=$(yq -r '.appVersion' $CHART_FILE)
+        trimmed_repo_url=$(echo $(Build.Repository.Uri) | | sed -e "s/\.git//g")
+        release_url=$(echo $trimmed_repo_url/releases/tag/v$appVersion-RELEASE)
+        echo "##vso[task.setvariable variable=version;isOutput=true]$version"
+        echo "##vso[task.setvariable variable=appVersion;isOutput=true]$appVersion"
+        echo "##vso[task.setvariable variable=release_url;isOutput=true]$releaseUrl"
+      failOnStderr: true
+  

--- a/.devops/azure-templates/chart-current-version.yml
+++ b/.devops/azure-templates/chart-current-version.yml
@@ -14,9 +14,9 @@ steps:
         version=$(yq -r '.version' $CHART_FILE)
         appVersion=$(yq -r '.appVersion' $CHART_FILE)
         trimmed_repo_url=$(echo $(Build.Repository.Uri) | sed -e "s/\.git//g")
-        release_url=$(echo $trimmed_repo_url/releases/tag/v$appVersion-RELEASE)
+        releaseUrl=$(echo $trimmed_repo_url/releases/tag/v$appVersion-RELEASE)
         echo "##vso[task.setvariable variable=version;isOutput=true]$version"
         echo "##vso[task.setvariable variable=appVersion;isOutput=true]$appVersion"
-        echo "##vso[task.setvariable variable=release_url;isOutput=true]$releaseUrl"
+        echo "##vso[task.setvariable variable=releaseUrl;isOutput=true]$releaseUrl"
       failOnStderr: true
   

--- a/.devops/deploy-pipelines.yml
+++ b/.devops/deploy-pipelines.yml
@@ -359,7 +359,7 @@ stages:
           timeoutInMinutes: 4320 # 3 days
           inputs:
             notifyUsers: $(APPROVE_TOUCHPOINT_MAIL)
-            instructions: "Please approve or reject $[ replace(variables['release_url'],'\"','') ] for PROD promotions"
+            instructions: "Please approve or reject ${{ replace(variables['release_url'],'\"','') }} for PROD promotions"
             onTimeout: 'reject'
 
   - stage: "Build_PROD_Blue"
@@ -454,7 +454,7 @@ stages:
           timeoutInMinutes: 4320 # 3 days
           inputs:
             notifyUsers: $(APPROVE_TOUCHPOINT_MAIL)
-            instructions: "Please approve or reject PROD green promotions $[ replace(variables['release_url'],'\"','') ]"
+            instructions: "Please approve or reject PROD green promotions ${{ replace(variables['release_url'],'\"','') }}"
             onTimeout: 'reject'                
 
   - stage: "Build_PROD_Green"
@@ -543,7 +543,7 @@ stages:
           timeoutInMinutes: 30
           inputs:
             notifyUsers: $(APPROVE_TOUCHPOINT_MAIL)
-            instructions: "Please approve or reject $[ replace(variables['release_url'],'\"','') ] for PROD promotions"
+            instructions: "Please approve or reject ${{ replace(variables['release_url'],'\"','') }} for PROD promotions"
             onTimeout: 'skip'
   - stage: "Prod_RollbackToLatestRelease"
     displayName: 'PROD rollback to the latest Release'

--- a/.devops/deploy-pipelines.yml
+++ b/.devops/deploy-pipelines.yml
@@ -348,6 +348,7 @@ stages:
     dependsOn: [Deploy_UAT_Green,Release]
     variables:
       prod_version: $[ stageDependencies.Release.make_release.outputs['current_version.value'] ]
+      release_url: $(Build.Repository.Uri)/releases/tag/$[replace($(prod_version),'\"','')]
     jobs:
       - job: Prod_Approval
         displayName: Manual prod deploy approval
@@ -358,7 +359,7 @@ stages:
           timeoutInMinutes: 4320 # 3 days
           inputs:
             notifyUsers: $(APPROVE_TOUCHPOINT_MAIL)
-            instructions: "Please approve or reject $(prod_version) for PROD promotions"
+            instructions: "Please approve or reject $(release_url) for PROD promotions"
             onTimeout: 'reject'
 
   - stage: "Build_PROD_Blue"
@@ -441,6 +442,8 @@ stages:
       dependsOn: Prod_WaitForApproval
     ${{ if eq(parameters['PROD_SKIP_BLUE_DEPLOYMENT'], False) }}:
       dependsOn: Blue_PROD_deployment
+    variables:
+      release_url: $(Build.Repository.Uri)/releases/tag/$[replace($(prod_version),'\"','')]
     jobs:
       - job: Bluegreen_PROD_WaitForApproval
         displayName: Manual green deploy approval
@@ -451,7 +454,7 @@ stages:
           timeoutInMinutes: 4320 # 3 days
           inputs:
             notifyUsers: $(APPROVE_TOUCHPOINT_MAIL)
-            instructions: "Please approve or reject PROD green promotions v${prod_version}"
+            instructions: "Please approve or reject PROD green promotions $(release_url)"
             onTimeout: 'reject'                
 
   - stage: "Build_PROD_Green"
@@ -529,6 +532,7 @@ stages:
     dependsOn: [Deploy_PROD_Green,Release]
     variables:
       prod_version: $[ stageDependencies.Release.make_release.outputs['current_version.value'] ]
+      release_url: $(Build.Repository.Uri)/releases/tag/$[replace($(prod_version),'\"','')]
     jobs:
       - job: Prod_Rollback_Approval
         displayName: Manual prod rollback approval
@@ -539,7 +543,7 @@ stages:
           timeoutInMinutes: 30
           inputs:
             notifyUsers: $(APPROVE_TOUCHPOINT_MAIL)
-            instructions: "Please approve or reject $(prod_version) for PROD promotions"
+            instructions: "Please approve or reject $(release_url) for PROD promotions"
             onTimeout: 'skip'
   - stage: "Prod_RollbackToLatestRelease"
     displayName: 'PROD rollback to the latest Release'

--- a/.devops/deploy-pipelines.yml
+++ b/.devops/deploy-pipelines.yml
@@ -348,7 +348,7 @@ stages:
     dependsOn: [Deploy_UAT_Green,Release]
     variables:
       prod_version: $[ stageDependencies.Release.make_release.outputs['current_version.value'] ]
-      release_url: $[replace( $[ format('{0}/releases/tag/{1}',variables['Build.Repository.Uri'], variables['prod_version'] '\"','')]
+      release_url: $[ format('{0}/releases/tag/{1}',variables['Build.Repository.Uri'], variables['prod_version'] ]
     jobs:
       - job: Prod_Approval
         displayName: Manual prod deploy approval
@@ -359,7 +359,7 @@ stages:
           timeoutInMinutes: 4320 # 3 days
           inputs:
             notifyUsers: $(APPROVE_TOUCHPOINT_MAIL)
-            instructions: "Please approve or reject $(release_url) for PROD promotions"
+            instructions: "Please approve or reject $[ replace(variables['release_url'],'\"','') ] for PROD promotions"
             onTimeout: 'reject'
 
   - stage: "Build_PROD_Blue"
@@ -443,7 +443,7 @@ stages:
     ${{ if eq(parameters['PROD_SKIP_BLUE_DEPLOYMENT'], False) }}:
       dependsOn: Blue_PROD_deployment
     variables:
-      release_url: $[replace( $[ format('{0}/releases/tag/{1}',variables['Build.Repository.Uri'], variables['prod_version'] '\"','')]
+      release_url: $[ format('{0}/releases/tag/{1}',variables['Build.Repository.Uri'], variables['prod_version'] ]
     jobs:
       - job: Bluegreen_PROD_WaitForApproval
         displayName: Manual green deploy approval
@@ -454,7 +454,7 @@ stages:
           timeoutInMinutes: 4320 # 3 days
           inputs:
             notifyUsers: $(APPROVE_TOUCHPOINT_MAIL)
-            instructions: "Please approve or reject PROD green promotions $(release_url)"
+            instructions: "Please approve or reject PROD green promotions $[ replace(variables['release_url'],'\"','') ]"
             onTimeout: 'reject'                
 
   - stage: "Build_PROD_Green"
@@ -532,7 +532,7 @@ stages:
     dependsOn: [Deploy_PROD_Green,Release]
     variables:
       prod_version: $[ stageDependencies.Release.make_release.outputs['current_version.value'] ]
-      release_url: $[replace( $[ format('{0}/releases/tag/{1}',variables['Build.Repository.Uri'], variables['prod_version'] '\"','')]
+      release_url: $[ format('{0}/releases/tag/{1}',variables['Build.Repository.Uri'], variables['prod_version'] ]
     jobs:
       - job: Prod_Rollback_Approval
         displayName: Manual prod rollback approval
@@ -543,7 +543,7 @@ stages:
           timeoutInMinutes: 30
           inputs:
             notifyUsers: $(APPROVE_TOUCHPOINT_MAIL)
-            instructions: "Please approve or reject $(release_url) for PROD promotions"
+            instructions: "Please approve or reject $[ replace(variables['release_url'],'\"','') ] for PROD promotions"
             onTimeout: 'skip'
   - stage: "Prod_RollbackToLatestRelease"
     displayName: 'PROD rollback to the latest Release'

--- a/.devops/deploy-pipelines.yml
+++ b/.devops/deploy-pipelines.yml
@@ -347,7 +347,7 @@ stages:
     displayName: 'PROD approval deployment'
     dependsOn: [Deploy_UAT_Green,Release]
     variables:
-      prod_version: $[ stageDependencies.Release.make_release.outputs['current_version.value'] ]
+      prod_version: ${{ stageDependencies.Release.make_release.outputs['current_version.value'] }}
     jobs:
       - job: Prod_Approval
         displayName: Manual prod deploy approval
@@ -440,7 +440,7 @@ stages:
     ${{ if eq(parameters['PROD_SKIP_BLUE_DEPLOYMENT'], True) }}:
       dependsOn: Prod_WaitForApproval
     ${{ if eq(parameters['PROD_SKIP_BLUE_DEPLOYMENT'], False) }}:
-      dependsOn: Blue_PROD_deployment
+      dependsOn: Blue_PROD_deployment 
     jobs:
       - job: Bluegreen_PROD_WaitForApproval
         displayName: Manual green deploy approval

--- a/.devops/deploy-pipelines.yml
+++ b/.devops/deploy-pipelines.yml
@@ -179,7 +179,7 @@ stages:
               DOCKER_IMAGE_NAME: $(K8S_IMAGE_REPOSITORY_NAME)
               DOCKER_IMAGE_TAG: $(Build.SourceVersion)
               FORCE_REPLACE_DOCKER_IMAGE: ${{ parameters.FORCE_REPLACE_DOCKER_IMAGE }}
-          - template: templates/node-github-current-version/template.yaml@pagopaCommons
+          - template: azure-templates/chart-current-version.yml
         
   - stage: "Deploy_UAT_Blue"
     displayName: 'UAT blue deployment'
@@ -190,7 +190,7 @@ stages:
       eq(${{parameters.UAT_SKIP_BLUE_DEPLOYMENT}}, False)
       )
     variables:
-      green_version: $[ stageDependencies.Build_release_candidate.build.outputs['current_version.value'] ]
+      green_version: $[ stageDependencies.Build_release_candidate.build.outputs['chart_current_version.appVersion'] ]
     jobs:
       - deployment: "Blue_deployment"
         displayName: "Blue deployment"
@@ -226,6 +226,9 @@ stages:
   - stage: "Bluegreen_WaitForApproval"
     displayName: 'UAT green approval deployment'
     dependsOn: Deploy_UAT_Blue
+    variables:
+      prod_version: $[ stageDependencies.Release.make_release.outputs['chart_current_version.appVersion'] ]
+      release_url: $[ stageDependencies.Release.make_release.outputs['chart_current_version.releaseUrl'] ]
     jobs:
       - job: Bluegreen_WaitForApproval
         displayName: Manual blue deploy approval
@@ -236,7 +239,7 @@ stages:
           timeoutInMinutes: 4320 # 3 days
           inputs:
             notifyUsers: $(APPROVE_TOUCHPOINT_MAIL)
-            instructions: "Please approve or reject UAT blue green promotions"
+            instructions: "Please approve or reject UAT blue green promotions for release $(release_url)"
             onTimeout: 'reject'
       - job: API_tests
         displayName: API test for blue deploy approval
@@ -278,16 +281,16 @@ stages:
                 release_branch: main
                 release_chart_semver: '${{ parameters.RELEASE_CHART_SEMVER }}'
           - ${{ if eq(parameters['SKIP_RELEASE'], False) }}:
-            - template: templates/node-github-current-version/template.yaml@pagopaCommons
+            - template: azure-templates/chart-current-version.yml
       - job: tag_version
         steps:
-          - template: templates/node-github-current-version/template.yaml@pagopaCommons
+          - template: azure-templates/chart-current-version.yml
 
   - stage: "Release_tag_docker"
     displayName: 'Docker tag release'
     dependsOn: Release
     variables:
-      next_version: $[ stageDependencies.Release.make_release.outputs['current_version.value'] ]
+      next_version: $[ stageDependencies.Release.make_release.outputs['chart_current_version.appVersion'] ]
     jobs:
       - job: "build"
         displayName: 'Build UAT service beta'
@@ -310,7 +313,7 @@ stages:
     displayName: 'UAT green deployment'
     dependsOn: [Release_tag_docker,Release]
     variables:
-      green_version: $[ stageDependencies.Release.make_release.outputs['current_version.value'] ]
+      green_version: $[ stageDependencies.Release.make_release.outputs['chart_current_version.appVersion'] ]
     jobs:
       - deployment: "Green_deployment"
         displayName: "Green deployment"
@@ -347,7 +350,8 @@ stages:
     displayName: 'PROD approval deployment'
     dependsOn: [Deploy_UAT_Green,Release]
     variables:
-      prod_version: $[ stageDependencies.Release.make_release.outputs['current_version.value'] ]
+      prod_version: $[ stageDependencies.Release.make_release.outputs['chart_current_version.appVersion'] ]
+      release_url: $[ stageDependencies.Release.make_release.outputs['chart_current_version.releaseUrl'] ]
     jobs:
       - job: Prod_Approval
         displayName: Manual prod deploy approval
@@ -358,7 +362,7 @@ stages:
           timeoutInMinutes: 4320 # 3 days
           inputs:
             notifyUsers: $(APPROVE_TOUCHPOINT_MAIL)
-            instructions: "Please approve or reject ${{ replace (format('{0}/releases/tag/{1}',variables['Build.Repository.Uri'],$(prod_version)), '\"', '' ) }} for PROD promotions"
+            instructions: "Please approve or reject PROD promotions for release $(release_url)"
             onTimeout: 'reject'
 
   - stage: "Build_PROD_Blue"
@@ -370,7 +374,7 @@ stages:
       )
     dependsOn: [Prod_WaitForApproval,Release]
     variables:
-      prod_version: $[ stageDependencies.Release.make_release.outputs['current_version.value'] ]
+      prod_version: $[ stageDependencies.Release.make_release.outputs['chart_current_version.appVersion'] ]
     jobs:
       - job: "PROD_image"
         displayName: 'Build PROD image'
@@ -402,7 +406,7 @@ stages:
     displayName: 'PROD blue deployment'
     dependsOn: [Build_PROD_Blue,Release]
     variables:
-      prod_version: $[ stageDependencies.Release.make_release.outputs['current_version.value'] ]
+      prod_version: $[ stageDependencies.Release.make_release.outputs['chart_current_version.appVersion'] ]
     jobs:
       - deployment: "Blue_PROD_deployment"
         displayName: "Blue PROD deployment"
@@ -440,7 +444,10 @@ stages:
     ${{ if eq(parameters['PROD_SKIP_BLUE_DEPLOYMENT'], True) }}:
       dependsOn: Prod_WaitForApproval
     ${{ if eq(parameters['PROD_SKIP_BLUE_DEPLOYMENT'], False) }}:
-      dependsOn: Blue_PROD_deployment 
+      dependsOn: Blue_PROD_deployment
+    variables:
+      prod_version: $[ stageDependencies.Release.make_release.outputs['chart_current_version.appVersion'] ]
+      release_url: $[ stageDependencies.Release.make_release.outputs['chart_current_version.releaseUrl'] ]
     jobs:
       - job: Bluegreen_PROD_WaitForApproval
         displayName: Manual green deploy approval
@@ -451,14 +458,14 @@ stages:
           timeoutInMinutes: 4320 # 3 days
           inputs:
             notifyUsers: $(APPROVE_TOUCHPOINT_MAIL)
-            instructions: "Please approve or reject PROD green promotions ${{ replace (format('{0}/releases/tag/{1}',variables['Build.Repository.Uri'],$(prod_version)), '\"', '' ) }}"
+            instructions: "Please approve or reject PROD green promotions for release $(release_url)"
             onTimeout: 'reject'                
 
   - stage: "Build_PROD_Green"
     displayName: 'PROD green Build'
     dependsOn: [PROD_Green_WaitForApproval,Release]
     variables:
-      prod_version: $[ stageDependencies.Release.make_release.outputs['current_version.value'] ]
+      prod_version: $[ stageDependencies.Release.make_release.outputs['chart_current_version.appVersion'] ]
     jobs:
       - job: "PROD_image"
         displayName: 'Build PROD image'
@@ -490,7 +497,7 @@ stages:
     displayName: 'PROD green deployment'
     dependsOn: [Build_PROD_Green,Release]
     variables:
-      prod_version: $[ stageDependencies.Release.make_release.outputs['current_version.value'] ]
+      prod_version: $[ stageDependencies.Release.make_release.outputs['chart_current_version.appVersion'] ]
     jobs:
     - deployment: "Green_PROD_deployment"
       displayName: "Green PROD deployment"
@@ -528,7 +535,8 @@ stages:
     displayName: 'PROD approval ROLLBACK'
     dependsOn: [Deploy_PROD_Green,Release]
     variables:
-      prod_version: $[ stageDependencies.Release.make_release.outputs['current_version.value'] ]
+      prod_version: $[ stageDependencies.Release.make_release.outputs['chart_current_version.appVersion'] ]
+      release_url: $[ stageDependencies.Release.make_release.outputs['chart_current_version.releaseUrl'] ]
     jobs:
       - job: Prod_Rollback_Approval
         displayName: Manual prod rollback approval
@@ -539,7 +547,7 @@ stages:
           timeoutInMinutes: 30
           inputs:
             notifyUsers: $(APPROVE_TOUCHPOINT_MAIL)
-            instructions: "Please approve or reject ${{ replace (format('{0}/releases/tag/{1}',variables['Build.Repository.Uri'],$(prod_version)), '\"', '' ) }} for PROD promotions"
+            instructions: "Please approve or reject PROD promotions for release $(release_url)"
             onTimeout: 'skip'
   - stage: "Prod_RollbackToLatestRelease"
     displayName: 'PROD rollback to the latest Release'

--- a/.devops/deploy-pipelines.yml
+++ b/.devops/deploy-pipelines.yml
@@ -190,7 +190,7 @@ stages:
       eq(${{parameters.UAT_SKIP_BLUE_DEPLOYMENT}}, False)
       )
     variables:
-      green_version: $[ stageDependencies.Build_release_candidate.build.outputs['chart_current_version.appVersion'] ]
+      green_app_version: $[ stageDependencies.Build_release_candidate.build.outputs['chart_current_version.appVersion'] ]
     jobs:
       - deployment: "Blue_deployment"
         displayName: "Blue deployment"
@@ -227,7 +227,7 @@ stages:
     displayName: 'UAT green approval deployment'
     dependsOn: Deploy_UAT_Blue
     variables:
-      prod_version: $[ stageDependencies.Release.make_release.outputs['chart_current_version.appVersion'] ]
+      prod_app_version: $[ stageDependencies.Release.make_release.outputs['chart_current_version.appVersion'] ]
       release_url: $[ stageDependencies.Release.make_release.outputs['chart_current_version.releaseUrl'] ]
     jobs:
       - job: Bluegreen_WaitForApproval
@@ -313,7 +313,7 @@ stages:
     displayName: 'UAT green deployment'
     dependsOn: [Release_tag_docker,Release]
     variables:
-      green_version: $[ stageDependencies.Release.make_release.outputs['chart_current_version.appVersion'] ]
+      green_app_version: $[ stageDependencies.Release.make_release.outputs['chart_current_version.appVersion'] ]
     jobs:
       - deployment: "Green_deployment"
         displayName: "Green deployment"
@@ -350,7 +350,7 @@ stages:
     displayName: 'PROD approval deployment'
     dependsOn: [Deploy_UAT_Green,Release]
     variables:
-      prod_version: $[ stageDependencies.Release.make_release.outputs['chart_current_version.appVersion'] ]
+      prod_app_version: $[ stageDependencies.Release.make_release.outputs['chart_current_version.appVersion'] ]
       release_url: $[ stageDependencies.Release.make_release.outputs['chart_current_version.releaseUrl'] ]
     jobs:
       - job: Prod_Approval
@@ -374,7 +374,7 @@ stages:
       )
     dependsOn: [Prod_WaitForApproval,Release]
     variables:
-      prod_version: $[ stageDependencies.Release.make_release.outputs['chart_current_version.appVersion'] ]
+      prod_app_version: $[ stageDependencies.Release.make_release.outputs['chart_current_version.appVersion'] ]
     jobs:
       - job: "PROD_image"
         displayName: 'Build PROD image'
@@ -406,7 +406,7 @@ stages:
     displayName: 'PROD blue deployment'
     dependsOn: [Build_PROD_Blue,Release]
     variables:
-      prod_version: $[ stageDependencies.Release.make_release.outputs['chart_current_version.appVersion'] ]
+      prod_app_version: $[ stageDependencies.Release.make_release.outputs['chart_current_version.appVersion'] ]
     jobs:
       - deployment: "Blue_PROD_deployment"
         displayName: "Blue PROD deployment"
@@ -446,7 +446,7 @@ stages:
     ${{ if eq(parameters['PROD_SKIP_BLUE_DEPLOYMENT'], False) }}:
       dependsOn: Blue_PROD_deployment
     variables:
-      prod_version: $[ stageDependencies.Release.make_release.outputs['chart_current_version.appVersion'] ]
+      prod_app_version: $[ stageDependencies.Release.make_release.outputs['chart_current_version.appVersion'] ]
       release_url: $[ stageDependencies.Release.make_release.outputs['chart_current_version.releaseUrl'] ]
     jobs:
       - job: Bluegreen_PROD_WaitForApproval
@@ -465,7 +465,7 @@ stages:
     displayName: 'PROD green Build'
     dependsOn: [PROD_Green_WaitForApproval,Release]
     variables:
-      prod_version: $[ stageDependencies.Release.make_release.outputs['chart_current_version.appVersion'] ]
+      prod_app_version: $[ stageDependencies.Release.make_release.outputs['chart_current_version.appVersion'] ]
     jobs:
       - job: "PROD_image"
         displayName: 'Build PROD image'
@@ -497,7 +497,7 @@ stages:
     displayName: 'PROD green deployment'
     dependsOn: [Build_PROD_Green,Release]
     variables:
-      prod_version: $[ stageDependencies.Release.make_release.outputs['chart_current_version.appVersion'] ]
+      prod_app_version: $[ stageDependencies.Release.make_release.outputs['chart_current_version.appVersion'] ]
     jobs:
     - deployment: "Green_PROD_deployment"
       displayName: "Green PROD deployment"
@@ -535,7 +535,7 @@ stages:
     displayName: 'PROD approval ROLLBACK'
     dependsOn: [Deploy_PROD_Green,Release]
     variables:
-      prod_version: $[ stageDependencies.Release.make_release.outputs['chart_current_version.appVersion'] ]
+      prod_app_version: $[ stageDependencies.Release.make_release.outputs['chart_current_version.appVersion'] ]
       release_url: $[ stageDependencies.Release.make_release.outputs['chart_current_version.releaseUrl'] ]
     jobs:
       - job: Prod_Rollback_Approval

--- a/.devops/deploy-pipelines.yml
+++ b/.devops/deploy-pipelines.yml
@@ -348,7 +348,7 @@ stages:
     dependsOn: [Deploy_UAT_Green,Release]
     variables:
       prod_version: $[ stageDependencies.Release.make_release.outputs['current_version.value'] ]
-      release_url: $(Build.Repository.Uri)/releases/tag/$[replace($(prod_version),'\"','')]
+      release_url: $[ join('/releases/tag/',{$(Build.Repository.Uri), $[replace($(prod_version),'"','')]}) ]
     jobs:
       - job: Prod_Approval
         displayName: Manual prod deploy approval
@@ -443,7 +443,7 @@ stages:
     ${{ if eq(parameters['PROD_SKIP_BLUE_DEPLOYMENT'], False) }}:
       dependsOn: Blue_PROD_deployment
     variables:
-      release_url: $(Build.Repository.Uri)/releases/tag/$[replace($(prod_version),'\"','')]
+      release_url: $[ join('/releases/tag/',{$(Build.Repository.Uri), $[replace($(prod_version),'"','')]}) ]
     jobs:
       - job: Bluegreen_PROD_WaitForApproval
         displayName: Manual green deploy approval
@@ -532,7 +532,7 @@ stages:
     dependsOn: [Deploy_PROD_Green,Release]
     variables:
       prod_version: $[ stageDependencies.Release.make_release.outputs['current_version.value'] ]
-      release_url: $(Build.Repository.Uri)/releases/tag/$[replace($(prod_version),'\"','')]
+      release_url: $[ join('/releases/tag/',{$(Build.Repository.Uri), $[replace($(prod_version),'"','')]}) ]
     jobs:
       - job: Prod_Rollback_Approval
         displayName: Manual prod rollback approval

--- a/.devops/deploy-pipelines.yml
+++ b/.devops/deploy-pipelines.yml
@@ -348,7 +348,7 @@ stages:
     dependsOn: [Deploy_UAT_Green,Release]
     variables:
       prod_version: $[ stageDependencies.Release.make_release.outputs['current_version.value'] ]
-      release_url: $[ join('/releases/tag/',{$(Build.Repository.Uri), $[replace($(prod_version),'"','')]}) ]
+      release_url: $[ join('/releases/tag/',$(Build.Repository.Uri), $[replace($(prod_version),'\"','')]) ]
     jobs:
       - job: Prod_Approval
         displayName: Manual prod deploy approval
@@ -443,7 +443,7 @@ stages:
     ${{ if eq(parameters['PROD_SKIP_BLUE_DEPLOYMENT'], False) }}:
       dependsOn: Blue_PROD_deployment
     variables:
-      release_url: $[ join('/releases/tag/',{$(Build.Repository.Uri), $[replace($(prod_version),'"','')]}) ]
+      release_url: $[ join('/releases/tag/',$(Build.Repository.Uri), $[replace($(prod_version),'\"','')]) ]
     jobs:
       - job: Bluegreen_PROD_WaitForApproval
         displayName: Manual green deploy approval
@@ -532,7 +532,7 @@ stages:
     dependsOn: [Deploy_PROD_Green,Release]
     variables:
       prod_version: $[ stageDependencies.Release.make_release.outputs['current_version.value'] ]
-      release_url: $[ join('/releases/tag/',{$(Build.Repository.Uri), $[replace($(prod_version),'"','')]}) ]
+      release_url: $[ join('/releases/tag/',$(Build.Repository.Uri), $[replace($(prod_version),'\"','')]) ]
     jobs:
       - job: Prod_Rollback_Approval
         displayName: Manual prod rollback approval

--- a/.devops/deploy-pipelines.yml
+++ b/.devops/deploy-pipelines.yml
@@ -348,7 +348,7 @@ stages:
     dependsOn: [Deploy_UAT_Green,Release]
     variables:
       prod_version: $[ stageDependencies.Release.make_release.outputs['current_version.value'] ]
-      release_url: $[ format('{0}/releases/tag/{1}',variables['Build.Repository.Uri'], variables['prod_version'] ]
+      release_url: $[ format('{0}/releases/tag/{1}',variables['Build.Repository.Uri'], variables['prod_version']) ]
     jobs:
       - job: Prod_Approval
         displayName: Manual prod deploy approval
@@ -443,7 +443,7 @@ stages:
     ${{ if eq(parameters['PROD_SKIP_BLUE_DEPLOYMENT'], False) }}:
       dependsOn: Blue_PROD_deployment
     variables:
-      release_url: $[ format('{0}/releases/tag/{1}',variables['Build.Repository.Uri'], variables['prod_version'] ]
+      release_url: $[ format('{0}/releases/tag/{1}',variables['Build.Repository.Uri'], variables['prod_version']) ]
     jobs:
       - job: Bluegreen_PROD_WaitForApproval
         displayName: Manual green deploy approval
@@ -532,7 +532,7 @@ stages:
     dependsOn: [Deploy_PROD_Green,Release]
     variables:
       prod_version: $[ stageDependencies.Release.make_release.outputs['current_version.value'] ]
-      release_url: $[ format('{0}/releases/tag/{1}',variables['Build.Repository.Uri'], variables['prod_version'] ]
+      release_url: $[ format('{0}/releases/tag/{1}',variables['Build.Repository.Uri'], variables['prod_version']) ]
     jobs:
       - job: Prod_Rollback_Approval
         displayName: Manual prod rollback approval

--- a/.devops/deploy-pipelines.yml
+++ b/.devops/deploy-pipelines.yml
@@ -347,7 +347,7 @@ stages:
     displayName: 'PROD approval deployment'
     dependsOn: [Deploy_UAT_Green,Release]
     variables:
-      prod_version: ${{ stageDependencies.Release.make_release.outputs['current_version.value'] }}
+      prod_version: $[ stageDependencies.Release.make_release.outputs['current_version.value'] ]
     jobs:
       - job: Prod_Approval
         displayName: Manual prod deploy approval
@@ -358,7 +358,7 @@ stages:
           timeoutInMinutes: 4320 # 3 days
           inputs:
             notifyUsers: $(APPROVE_TOUCHPOINT_MAIL)
-            instructions: "Please approve or reject ${{ replace (format('{0}/releases/tag/{1}',variables['Build.Repository.Uri'], variables['prod_version']), '\"', '' ) }} for PROD promotions"
+            instructions: "Please approve or reject ${{ replace (format('{0}/releases/tag/{1}',variables['Build.Repository.Uri'], variables['prod_version'].value), '\"', '' ) }} for PROD promotions"
             onTimeout: 'reject'
 
   - stage: "Build_PROD_Blue"

--- a/.devops/deploy-pipelines.yml
+++ b/.devops/deploy-pipelines.yml
@@ -359,7 +359,7 @@ stages:
           timeoutInMinutes: 4320 # 3 days
           inputs:
             notifyUsers: $(APPROVE_TOUCHPOINT_MAIL)
-            instructions: "Please approve or reject ${{ replace(variables['release_url'],'\"','') }} for PROD promotions"
+            instructions: "Please approve or reject ${{ replace(variables.release_url,'\"','') }} for PROD promotions"
             onTimeout: 'reject'
 
   - stage: "Build_PROD_Blue"
@@ -454,7 +454,7 @@ stages:
           timeoutInMinutes: 4320 # 3 days
           inputs:
             notifyUsers: $(APPROVE_TOUCHPOINT_MAIL)
-            instructions: "Please approve or reject PROD green promotions ${{ replace(variables['release_url'],'\"','') }}"
+            instructions: "Please approve or reject PROD green promotions ${{ replace(variables.release_url,'\"','') }}"
             onTimeout: 'reject'                
 
   - stage: "Build_PROD_Green"
@@ -543,7 +543,7 @@ stages:
           timeoutInMinutes: 30
           inputs:
             notifyUsers: $(APPROVE_TOUCHPOINT_MAIL)
-            instructions: "Please approve or reject ${{ replace(variables['release_url'],'\"','') }} for PROD promotions"
+            instructions: "Please approve or reject ${{ replace(variables.release_url,'\"','') }} for PROD promotions"
             onTimeout: 'skip'
   - stage: "Prod_RollbackToLatestRelease"
     displayName: 'PROD rollback to the latest Release'

--- a/.devops/deploy-pipelines.yml
+++ b/.devops/deploy-pipelines.yml
@@ -348,7 +348,6 @@ stages:
     dependsOn: [Deploy_UAT_Green,Release]
     variables:
       prod_version: $[ stageDependencies.Release.make_release.outputs['current_version.value'] ]
-      release_url: ${{ replace (format('{0}/releases/tag/{1}',variables['Build.Repository.Uri'], variables['prod_version']), '\"', '' ) }}
     jobs:
       - job: Prod_Approval
         displayName: Manual prod deploy approval
@@ -359,7 +358,7 @@ stages:
           timeoutInMinutes: 4320 # 3 days
           inputs:
             notifyUsers: $(APPROVE_TOUCHPOINT_MAIL)
-            instructions: "Please approve or reject $(release_url) for PROD promotions"
+            instructions: "Please approve or reject ${{ replace (format('{0}/releases/tag/{1}',variables['Build.Repository.Uri'], variables['prod_version']), '\"', '' ) }} for PROD promotions"
             onTimeout: 'reject'
 
   - stage: "Build_PROD_Blue"
@@ -442,8 +441,6 @@ stages:
       dependsOn: Prod_WaitForApproval
     ${{ if eq(parameters['PROD_SKIP_BLUE_DEPLOYMENT'], False) }}:
       dependsOn: Blue_PROD_deployment
-    variables:
-      release_url: ${{ replace (format('{0}/releases/tag/{1}',variables['Build.Repository.Uri'], variables['prod_version']), '\"', '' ) }}
     jobs:
       - job: Bluegreen_PROD_WaitForApproval
         displayName: Manual green deploy approval
@@ -454,7 +451,7 @@ stages:
           timeoutInMinutes: 4320 # 3 days
           inputs:
             notifyUsers: $(APPROVE_TOUCHPOINT_MAIL)
-            instructions: "Please approve or reject PROD green promotions $(release_url)"
+            instructions: "Please approve or reject PROD green promotions ${{ replace (format('{0}/releases/tag/{1}',variables['Build.Repository.Uri'], variables['prod_version']), '\"', '' ) }}"
             onTimeout: 'reject'                
 
   - stage: "Build_PROD_Green"
@@ -532,7 +529,6 @@ stages:
     dependsOn: [Deploy_PROD_Green,Release]
     variables:
       prod_version: $[ stageDependencies.Release.make_release.outputs['current_version.value'] ]
-      release_url: ${{ replace (format('{0}/releases/tag/{1}',variables['Build.Repository.Uri'], variables['prod_version']), '\"', '' ) }}
     jobs:
       - job: Prod_Rollback_Approval
         displayName: Manual prod rollback approval
@@ -543,7 +539,7 @@ stages:
           timeoutInMinutes: 30
           inputs:
             notifyUsers: $(APPROVE_TOUCHPOINT_MAIL)
-            instructions: "Please approve or reject $(release_url) for PROD promotions"
+            instructions: "Please approve or reject ${{ replace (format('{0}/releases/tag/{1}',variables['Build.Repository.Uri'], variables['prod_version']), '\"', '' ) }} for PROD promotions"
             onTimeout: 'skip'
   - stage: "Prod_RollbackToLatestRelease"
     displayName: 'PROD rollback to the latest Release'

--- a/.devops/deploy-pipelines.yml
+++ b/.devops/deploy-pipelines.yml
@@ -358,7 +358,7 @@ stages:
           timeoutInMinutes: 4320 # 3 days
           inputs:
             notifyUsers: $(APPROVE_TOUCHPOINT_MAIL)
-            instructions: "Please approve or reject ${{ replace (format('{0}/releases/tag/{1}',variables['Build.Repository.Uri'], variables['prod_version'].value), '\"', '' ) }} for PROD promotions"
+            instructions: "Please approve or reject ${{ replace (format('{0}/releases/tag/{1}',variables['Build.Repository.Uri'],$(prod_version)), '\"', '' ) }} for PROD promotions"
             onTimeout: 'reject'
 
   - stage: "Build_PROD_Blue"
@@ -451,7 +451,7 @@ stages:
           timeoutInMinutes: 4320 # 3 days
           inputs:
             notifyUsers: $(APPROVE_TOUCHPOINT_MAIL)
-            instructions: "Please approve or reject PROD green promotions ${{ replace (format('{0}/releases/tag/{1}',variables['Build.Repository.Uri'], variables['prod_version']), '\"', '' ) }}"
+            instructions: "Please approve or reject PROD green promotions ${{ replace (format('{0}/releases/tag/{1}',variables['Build.Repository.Uri'],$(prod_version)), '\"', '' ) }}"
             onTimeout: 'reject'                
 
   - stage: "Build_PROD_Green"
@@ -539,7 +539,7 @@ stages:
           timeoutInMinutes: 30
           inputs:
             notifyUsers: $(APPROVE_TOUCHPOINT_MAIL)
-            instructions: "Please approve or reject ${{ replace (format('{0}/releases/tag/{1}',variables['Build.Repository.Uri'], variables['prod_version']), '\"', '' ) }} for PROD promotions"
+            instructions: "Please approve or reject ${{ replace (format('{0}/releases/tag/{1}',variables['Build.Repository.Uri'],$(prod_version)), '\"', '' ) }} for PROD promotions"
             onTimeout: 'skip'
   - stage: "Prod_RollbackToLatestRelease"
     displayName: 'PROD rollback to the latest Release'

--- a/.devops/deploy-pipelines.yml
+++ b/.devops/deploy-pipelines.yml
@@ -348,7 +348,7 @@ stages:
     dependsOn: [Deploy_UAT_Green,Release]
     variables:
       prod_version: $[ stageDependencies.Release.make_release.outputs['current_version.value'] ]
-      release_url: $[ format('{0}/releases/tag/{1}',variables['Build.Repository.Uri'], $[replace(variables['prod_version'],'\"','')]) ]
+      release_url: $[replace( $[ format('{0}/releases/tag/{1}',variables['Build.Repository.Uri'], variables['prod_version'] '\"','')]
     jobs:
       - job: Prod_Approval
         displayName: Manual prod deploy approval
@@ -443,7 +443,7 @@ stages:
     ${{ if eq(parameters['PROD_SKIP_BLUE_DEPLOYMENT'], False) }}:
       dependsOn: Blue_PROD_deployment
     variables:
-      release_url: $[ format('{0}/releases/tag/{1}',variables['Build.Repository.Uri'], $[replace(variables['prod_version'],'\"','')]) ]
+      release_url: $[replace( $[ format('{0}/releases/tag/{1}',variables['Build.Repository.Uri'], variables['prod_version'] '\"','')]
     jobs:
       - job: Bluegreen_PROD_WaitForApproval
         displayName: Manual green deploy approval
@@ -532,7 +532,7 @@ stages:
     dependsOn: [Deploy_PROD_Green,Release]
     variables:
       prod_version: $[ stageDependencies.Release.make_release.outputs['current_version.value'] ]
-      release_url: $[ format('{0}/releases/tag/{1}',variables['Build.Repository.Uri'], $[replace(variables['prod_version'],'\"','')]) ]
+      release_url: $[replace( $[ format('{0}/releases/tag/{1}',variables['Build.Repository.Uri'], variables['prod_version'] '\"','')]
     jobs:
       - job: Prod_Rollback_Approval
         displayName: Manual prod rollback approval

--- a/.devops/deploy-pipelines.yml
+++ b/.devops/deploy-pipelines.yml
@@ -348,7 +348,7 @@ stages:
     dependsOn: [Deploy_UAT_Green,Release]
     variables:
       prod_version: $[ stageDependencies.Release.make_release.outputs['current_version.value'] ]
-      release_url: $[ join('/releases/tag/',$(Build.Repository.Uri), $[replace($(prod_version),'\"','')]) ]
+      release_url: $[ join('/releases/tag/',variables['Build.Repository.Uri'], $[replace(variables['prod_version'],'\"','')]) ]
     jobs:
       - job: Prod_Approval
         displayName: Manual prod deploy approval
@@ -443,7 +443,7 @@ stages:
     ${{ if eq(parameters['PROD_SKIP_BLUE_DEPLOYMENT'], False) }}:
       dependsOn: Blue_PROD_deployment
     variables:
-      release_url: $[ join('/releases/tag/',$(Build.Repository.Uri), $[replace($(prod_version),'\"','')]) ]
+      release_url: $[ join('/releases/tag/',variables['Build.Repository.Uri'], $[replace(variables['prod_version'],'\"','')]) ]
     jobs:
       - job: Bluegreen_PROD_WaitForApproval
         displayName: Manual green deploy approval
@@ -532,7 +532,7 @@ stages:
     dependsOn: [Deploy_PROD_Green,Release]
     variables:
       prod_version: $[ stageDependencies.Release.make_release.outputs['current_version.value'] ]
-      release_url: $[ join('/releases/tag/',$(Build.Repository.Uri), $[replace($(prod_version),'\"','')]) ]
+      release_url: $[ join('/releases/tag/',variables['Build.Repository.Uri'], $[replace(variables['prod_version'],'\"','')]) ]
     jobs:
       - job: Prod_Rollback_Approval
         displayName: Manual prod rollback approval

--- a/.devops/deploy-pipelines.yml
+++ b/.devops/deploy-pipelines.yml
@@ -348,7 +348,7 @@ stages:
     dependsOn: [Deploy_UAT_Green,Release]
     variables:
       prod_version: $[ stageDependencies.Release.make_release.outputs['current_version.value'] ]
-      release_url: $[ format('{0}/releases/tag/{1}',variables['Build.Repository.Uri'], variables['prod_version']) ]
+      release_url: ${{ replace (format('{0}/releases/tag/{1}',variables['Build.Repository.Uri'], variables['prod_version']), '\"', '' ) }}
     jobs:
       - job: Prod_Approval
         displayName: Manual prod deploy approval
@@ -359,7 +359,7 @@ stages:
           timeoutInMinutes: 4320 # 3 days
           inputs:
             notifyUsers: $(APPROVE_TOUCHPOINT_MAIL)
-            instructions: "Please approve or reject ${{ replace(variables.release_url,'\"','') }} for PROD promotions"
+            instructions: "Please approve or reject $(release_url) for PROD promotions"
             onTimeout: 'reject'
 
   - stage: "Build_PROD_Blue"
@@ -443,7 +443,7 @@ stages:
     ${{ if eq(parameters['PROD_SKIP_BLUE_DEPLOYMENT'], False) }}:
       dependsOn: Blue_PROD_deployment
     variables:
-      release_url: $[ format('{0}/releases/tag/{1}',variables['Build.Repository.Uri'], variables['prod_version']) ]
+      release_url: ${{ replace (format('{0}/releases/tag/{1}',variables['Build.Repository.Uri'], variables['prod_version']), '\"', '' ) }}
     jobs:
       - job: Bluegreen_PROD_WaitForApproval
         displayName: Manual green deploy approval
@@ -454,7 +454,7 @@ stages:
           timeoutInMinutes: 4320 # 3 days
           inputs:
             notifyUsers: $(APPROVE_TOUCHPOINT_MAIL)
-            instructions: "Please approve or reject PROD green promotions ${{ replace(variables.release_url,'\"','') }}"
+            instructions: "Please approve or reject PROD green promotions $(release_url)"
             onTimeout: 'reject'                
 
   - stage: "Build_PROD_Green"
@@ -532,7 +532,7 @@ stages:
     dependsOn: [Deploy_PROD_Green,Release]
     variables:
       prod_version: $[ stageDependencies.Release.make_release.outputs['current_version.value'] ]
-      release_url: $[ format('{0}/releases/tag/{1}',variables['Build.Repository.Uri'], variables['prod_version']) ]
+      release_url: ${{ replace (format('{0}/releases/tag/{1}',variables['Build.Repository.Uri'], variables['prod_version']), '\"', '' ) }}
     jobs:
       - job: Prod_Rollback_Approval
         displayName: Manual prod rollback approval
@@ -543,7 +543,7 @@ stages:
           timeoutInMinutes: 30
           inputs:
             notifyUsers: $(APPROVE_TOUCHPOINT_MAIL)
-            instructions: "Please approve or reject ${{ replace(variables.release_url,'\"','') }} for PROD promotions"
+            instructions: "Please approve or reject $(release_url) for PROD promotions"
             onTimeout: 'skip'
   - stage: "Prod_RollbackToLatestRelease"
     displayName: 'PROD rollback to the latest Release'

--- a/.devops/deploy-pipelines.yml
+++ b/.devops/deploy-pipelines.yml
@@ -348,7 +348,7 @@ stages:
     dependsOn: [Deploy_UAT_Green,Release]
     variables:
       prod_version: $[ stageDependencies.Release.make_release.outputs['current_version.value'] ]
-      release_url: $[ join('/releases/tag/',variables['Build.Repository.Uri'], $[replace(variables['prod_version'],'\"','')]) ]
+      release_url: $[ format('{0}/releases/tag/{1}',variables['Build.Repository.Uri'], $[replace(variables['prod_version'],'\"','')]) ]
     jobs:
       - job: Prod_Approval
         displayName: Manual prod deploy approval
@@ -443,7 +443,7 @@ stages:
     ${{ if eq(parameters['PROD_SKIP_BLUE_DEPLOYMENT'], False) }}:
       dependsOn: Blue_PROD_deployment
     variables:
-      release_url: $[ join('/releases/tag/',variables['Build.Repository.Uri'], $[replace(variables['prod_version'],'\"','')]) ]
+      release_url: $[ format('{0}/releases/tag/{1}',variables['Build.Repository.Uri'], $[replace(variables['prod_version'],'\"','')]) ]
     jobs:
       - job: Bluegreen_PROD_WaitForApproval
         displayName: Manual green deploy approval
@@ -532,7 +532,7 @@ stages:
     dependsOn: [Deploy_PROD_Green,Release]
     variables:
       prod_version: $[ stageDependencies.Release.make_release.outputs['current_version.value'] ]
-      release_url: $[ join('/releases/tag/',variables['Build.Repository.Uri'], $[replace(variables['prod_version'],'\"','')]) ]
+      release_url: $[ format('{0}/releases/tag/{1}',variables['Build.Repository.Uri'], $[replace(variables['prod_version'],'\"','')]) ]
     jobs:
       - job: Prod_Rollback_Approval
         displayName: Manual prod rollback approval


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->

1. Add `chart-current-version` custom template that read Chart.yaml file and outputs the following variables:

- version --> the Chart version
- appVersion -> the Chart appVersion
- releaseUrl -> the github release url, based on the above app version, as an URL build as `<<github-repo-url>>/releases/tag/v<<appVersion>>-RELEASE`

2. Modified UAT and PROD environments manual approval instructions including release url into messages 
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Those modifications add the currently deploying release URL so that release can be easily check just copy-pasting release url.
Unfortunately hyperlinks are not supported by instruction messages that threat the whole builded message as a plain text, see https://developercommunity.visualstudio.com/t/azure-devops-manual-validation-tasks-instruction-i/1552914

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Deploy pipeline (see this [pipeline run](https://dev.azure.com/pagopaspa/pagoPA-projects/_build/results?buildId=100627&view=results), in particular Manual Validation displayed instruction message)
#### Screenshots (if appropriate):
<img width="1482" alt="Screenshot 2023-06-17 alle 02 19 31" src="https://github.com/pagopa/pagopa-notifications-service/assets/115724836/6f22a0f5-c437-4724-96e6-89da82e85b52">

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
