### PR TITLE
feat: [CHK-3779] upgrade to helm chart 7

### DIFF
--- a/helm/Chart.lock
+++ b/helm/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: microservice-chart
   repository: https://pagopa.github.io/aks-microservice-chart-blueprint
-  version: 2.3.1
-digest: sha256:92b42c64847373faa6bf054181be2d7ee61e8b6b6d6a5552bf1479691aa95df3
-generated: "2023-01-25T10:38:49.539324+01:00"
+  version: 7.4.0
+digest: sha256:ba6c74f4d1b23251f9256f33bbc5ac6eaaf586569c0b43e37ad413f6d36ceabe
+generated: "2025-03-06T15:22:50.156098+01:00"

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -6,5 +6,5 @@ version: 1.7.0
 appVersion: 1.8.0
 dependencies:
   - name: microservice-chart
-    version: 2.3.1
+    version: 7.4.0
     repository: "https://pagopa.github.io/aks-microservice-chart-blueprint"

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -2,6 +2,20 @@ microservice-chart:
   namespace: "ecommerce"
   nameOverride: ""
   fullnameOverride: ""
+  canaryDelivery:
+    create: false
+    ingress:
+      bluegreen: false
+      #set canary deployment with traffic balancing see https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/nginx-configuration/annotations.md#canary for more info
+      header: true
+      headerName: deployment
+      headerValue: blue
+      weightPercent: 10
+    image:
+      repository: pagopadcommonacr.azurecr.io/pagopanotificationsservice
+      tag: "latest"
+    envConfig: {}
+    envSecret: {}
   image:
     repository: pagopadcommonacr.azurecr.io/pagopanotificationsservice
     tag: "1.8.0"
@@ -34,8 +48,8 @@ microservice-chart:
     servicePort: 3000
   serviceAccount:
     create: false
-    annotations: {}
-    name: ""
+    annotations: { }
+    name: "ecommerce-workload-identity"
   podAnnotations: {}
   podSecurityContext:
     seccompProfile:
@@ -103,10 +117,6 @@ microservice-chart:
     tenantId: "7788edaf-0346-4068-9d79-c868aed15b3d"
   nodeSelector: {}
   tolerations: []
-  canaryDelivery:
-    deployment:
-      image:
-        tag: ""
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
@@ -116,3 +126,5 @@ microservice-chart:
                 operator: In
                 values:
                   - user
+  azure:
+    workloadIdentityClientId: 1be61b58-24e2-49c8-b401-89ebd004bf2e

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -5,42 +5,18 @@ microservice-chart:
   canaryDelivery:
     create: false
     ingress:
-      create: true
-      canary:
-        type: bluegreen
-    service:
-      create: true
-    deployment:
-      create: true
+      bluegreen: false
+      #set canary deployment with traffic balancing see https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/nginx-configuration/annotations.md#canary for more info
+      header: true
+      headerName: deployment
+      headerValue: blue
+      weightPercent: 10
       image:
         repository: pagopapcommonacr.azurecr.io/pagopanotificationsservice
-        tag: ""
-        pullPolicy: Always
+        tag: "latest"
       envConfig:
-        NOTIFICATIONS_EMAIL_ENABLED: "true"
-        AWS_SES_REGION: "eu-south-1"
-        CLIENT_ECOMMERCE_TEST: "{\"TEMPLATE_IDS\":[\"poc-1\", \"success\", \"ko\"]}"
-        CLIENT_PAYMENT_MANAGER: "{\"TEMPLATE_IDS\":[\"poc-1\", \"success\", \"ko\"]}"
-        CLIENT_ECOMMERCE: "{\"TEMPLATE_IDS\":[\"poc-1\", \"success\", \"ko\"]}"
-        RETRY_QUEUE_NAME: "pagopa-p-weu-ecommerce-notifications-service-retry-queue"
-        ERROR_QUEUE_NAME: "pagopa-p-weu-ecommerce-notifications-service-errors-queue"
-        AI_SAMPLING_PERCENTAGE: "30"
-        AI_ENABLED: "true"
-        PERSONAL_DATA_VAULT_API_HOST: "https://api.tokenizer.pdv.pagopa.it"
-        PERSONAL_DATA_VAULT_API_BASE_PATH: "/tokenizer/v1"
-        PAGOPA_MAIL_LOGO_URI: "https://checkout.pagopa.it/assets/logos/logo_pagopa.png"
         ELASTIC_APM_SERVICE_NAME: pagopa-notification-service-blue
-        ELASTIC_APM_SERVER_URL: http://quickstart-apm-http.elastic-system.svc:8200
-        ELASTIC_APM_ENVIRONMENT: "prod"
-        SERVER_KEEP_ALIVE: "61000"
-      envSecret:
-        AWS_SES_ACCESS_KEY_ID: aws-ses-accesskey-id
-        AWS_SES_SECRET_ACCESS_KEY: aws-ses-secretaccess-key
-        STORAGE_TRANSIENT_CONNECTION_STRING: ecommerce-storage-transient-connection-string
-        STORAGE_DEADLETTER_CONNECTION_STRING: ecommerce-storage-deadletter-connection-string
-        PERSONAL_DATA_VAULT_API_KEY: personal-data-vault-api-key
-        ECOMMERCE_NOTIFICATIONS_SENDER: notifications-sender
-        ELASTIC_APM_SECRET_TOKEN: elastic-apm-secret-token
+      envSecret: {}
   image:
     repository: pagopapcommonacr.azurecr.io/pagopanotificationsservice
     tag: "1.8.0"
@@ -74,8 +50,8 @@ microservice-chart:
     servicePort: 3000
   serviceAccount:
     create: false
-    annotations: {}
-    name: ""
+    annotations: { }
+    name: "ecommerce-workload-identity"
   podAnnotations: {}
   podSecurityContext:
     seccompProfile:
@@ -155,3 +131,5 @@ microservice-chart:
                 app.kubernetes.io/instance: pagopanotificationsservice
             namespaces: ["ecommerce"]
             topologyKey: topology.kubernetes.io/zone
+  azure:
+    workloadIdentityClientId: "d5614882-90dd-47a1-aad1-cdf295201469"

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -5,42 +5,19 @@ microservice-chart:
   canaryDelivery:
     create: false
     ingress:
-      create: true
-      canary:
-        type: bluegreen
-    service:
-      create: true
-    deployment:
-      create: true
+      bluegreen: false
+      #set canary deployment with traffic balancing see https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/nginx-configuration/annotations.md#canary for more info
+      header: true
+      headerName: deployment
+      headerValue: blue
+      weightPercent: 10
+    image:
       image:
         repository: pagopaucommonacr.azurecr.io/pagopanotificationsservice
-        tag: ""
-        pullPolicy: Always
+        tag: "latest"
       envConfig:
-        NOTIFICATIONS_EMAIL_ENABLED: "true"
-        AWS_SES_REGION: "eu-south-1"
-        CLIENT_ECOMMERCE_TEST: "{\"TEMPLATE_IDS\":[\"poc-1\", \"success\", \"ko\"]}"
-        CLIENT_PAYMENT_MANAGER: "{\"TEMPLATE_IDS\":[\"poc-1\", \"success\", \"ko\"]}"
-        CLIENT_ECOMMERCE: "{\"TEMPLATE_IDS\":[\"poc-1\", \"success\", \"ko\"]}"
-        RETRY_QUEUE_NAME: "pagopa-u-weu-ecommerce-notifications-service-retry-queue"
-        ERROR_QUEUE_NAME: "pagopa-u-weu-ecommerce-notifications-service-errors-queue"
-        AI_SAMPLING_PERCENTAGE: "30"
-        AI_ENABLED: "true"
-        PERSONAL_DATA_VAULT_API_HOST: "https://api.uat.tokenizer.pdv.pagopa.it"
-        PERSONAL_DATA_VAULT_API_BASE_PATH: "/tokenizer/v1"
-        PAGOPA_MAIL_LOGO_URI: "https://dev.checkout.pagopa.it/assets/logos/logo_pagopa.png"
         ELASTIC_APM_SERVICE_NAME: pagopa-notification-service-blue
-        ELASTIC_APM_SERVER_URL: http://quickstart-apm-http.elastic-system.svc:8200
-        ELASTIC_APM_ENVIRONMENT: "uat"
-        SERVER_KEEP_ALIVE: "61000"
-      envSecret:
-        AWS_SES_ACCESS_KEY_ID: aws-ses-accesskey-id
-        AWS_SES_SECRET_ACCESS_KEY: aws-ses-secretaccess-key
-        STORAGE_TRANSIENT_CONNECTION_STRING: ecommerce-storage-transient-connection-string
-        STORAGE_DEADLETTER_CONNECTION_STRING: ecommerce-storage-deadletter-connection-string
-        PERSONAL_DATA_VAULT_API_KEY: personal-data-vault-api-key
-        ECOMMERCE_NOTIFICATIONS_SENDER: notifications-sender
-        ELASTIC_APM_SECRET_TOKEN: elastic-apm-secret-token
+      envSecret: {}
   image:
     repository: pagopaucommonacr.azurecr.io/pagopanotificationsservice
     tag: "1.8.0"
@@ -74,8 +51,8 @@ microservice-chart:
     servicePort: 3000
   serviceAccount:
     create: false
-    annotations: {}
-    name: ""
+    annotations: { }
+    name: "ecommerce-workload-identity"
   podAnnotations: {}
   podSecurityContext:
     seccompProfile:
@@ -123,7 +100,7 @@ microservice-chart:
     ERROR_QUEUE_NAME: "pagopa-u-weu-ecommerce-notifications-service-errors-queue"
     AI_SAMPLING_PERCENTAGE: "30"
     AI_ENABLED: "true"
-    PAGOPA_MAIL_LOGO_URI: "https://dev.checkout.pagopa.it/assets/logos/logo_pagopa.png"
+    PAGOPA_MAIL_LOGO_URI: "https://uat.checkout.pagopa.it/assets/logos/logo_pagopa.png"
     PERSONAL_DATA_VAULT_API_HOST: "https://api.uat.tokenizer.pdv.pagopa.it"
     PERSONAL_DATA_VAULT_API_BASE_PATH: "/tokenizer/v1"
     ELASTIC_APM_SERVICE_NAME: pagopa-notification-service
@@ -152,3 +129,5 @@ microservice-chart:
                 operator: In
                 values:
                   - user
+  azure:
+    workloadIdentityClientId: 449c5b65-f368-487a-881a-b03676420c53


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

Upgrade to helm chart 7 from helm chart 2.

#### List of Changes
Upgrade to helm chart 7 performing the following modifications:
- chat version update from 2.3.1 to 7.4.0
- canaryDelivery parameter update to the new template (adding canary section)
- add workload identity refs for each environment specifying the azure workload identity client id and service account name for each env
- canary env variables clean action to just keep the different ones

#### Motivation and Context
These modifications are needed to enable the eCommerce notifications service to use workload identities instead of the deprecated pod identity.
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

No tests yet

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.