### PR TITLE
feat: [CHK-3967] loading templates in async and cache them

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -6,6 +6,8 @@ module.exports = {
     "**/__tests__/*.ts"
   ],
   setupFiles: ["<rootDir>/jest.setup.js"],
+  // Tell Jest to ignore the dist directory for mocks
+  modulePathIgnorePatterns: ["<rootDir>/dist/"],
   rootDir: ".",
   moduleNameMapper: {
     '^[./a-zA-Z0-9$_-]+\\/success/schema.js$':'<rootDir>/dist/src/generated/templates/success/schema.js',

--- a/src/__tests__/RetryQueueListener.test.ts
+++ b/src/__tests__/RetryQueueListener.test.ts
@@ -9,6 +9,7 @@ import { addRetryQueueListener } from "../queues/RetryQueueListener";
 import { QueueReceiveMessageResponse } from "@azure/storage-queue";
 import registerHelpers from "handlebars-helpers";
 import { mockReq } from "../__mocks__/data_mock";
+import * as fs from "fs";
 
 describe("retry queue", () => {
 
@@ -47,9 +48,28 @@ describe("retry queue", () => {
     return Promise.resolve(messageId);
   });
 
+  const mockLoadTemplate = (path: any) => {
+    const pathStr = typeof path === 'string' 
+      ? path 
+      : path instanceof URL 
+        ? path.toString() 
+        : path instanceof Buffer 
+          ? path.toString() 
+          : path.toString();
+    
+    if (pathStr.includes('.template.txt')) {
+      return Promise.resolve('Text template');
+    } else if (pathStr.includes('.template.html')) {
+      return Promise.resolve('<html>HTML template</html>');
+    }
+    return Promise.reject(new Error(`File not found: ${pathStr}`));
+  }
+
   retryQueueClient.deleteMessage = mockDeleteMessage;
 
   it("sendMessageToRetryQueue", async () => {
+    jest.spyOn(fs.promises, 'readFile').mockImplementation(mockLoadTemplate);
+
     jest.useFakeTimers();
     const emailMockedFunction = jest.fn();
     registerHelpers();

--- a/src/__tests__/RetryQueueListener.test.ts
+++ b/src/__tests__/RetryQueueListener.test.ts
@@ -1,6 +1,5 @@
-
 import { retryQueueClient } from "../util/queues";
-import { apiPdvClient } from "../util/confidentialDataManager";
+import { apiPdvClient, encryptBody } from "../util/confidentialDataManager";
 import { getConfigOrThrow } from "../util/config";
 import { Envelope } from "nodemailer/lib/mime-node";
 import { SentMessageInfo } from "nodemailer/lib/ses-transport";
@@ -10,6 +9,46 @@ import { QueueReceiveMessageResponse } from "@azure/storage-queue";
 import registerHelpers from "handlebars-helpers";
 import { mockReq } from "../__mocks__/data_mock";
 import * as fs from "fs";
+import * as O from "fp-ts/lib/Option";
+import * as E from "fp-ts/lib/Either";
+import * as TE from "fp-ts/lib/TaskEither";
+import { pipe } from "fp-ts/lib/function";
+import { sendMessageToErrorQueue } from "../queues/ErrorQueue";
+import { sendEmail, writeMessageIntoQueue } from "../controllers/EmailsControllers";
+import { logger } from "../util/logger";
+import { Type } from "io-ts";
+
+// Mock dependencies for retry tests
+jest.mock("../queues/ErrorQueue", () => ({
+  sendMessageToErrorQueue: jest.fn().mockResolvedValue({})
+}));
+
+jest.mock("../util/logger", () => ({
+  logger: {
+    info: jest.fn(),
+    error: jest.fn()
+  }
+}));
+
+// Properly mock the confidentialDataManager module
+jest.mock("../util/confidentialDataManager", () => {
+  const original = jest.requireActual("../util/confidentialDataManager");
+  return {
+    ...original,
+    encryptBody: jest.fn().mockImplementation(() => TE.right("encrypted-body")),
+    apiPdvClient: {
+      ...original.apiPdvClient,
+      findPiiUsingGET: jest.fn().mockResolvedValue({
+        _tag: "Right", 
+        right: { 
+          status: 200, 
+          value: { pii: JSON.stringify({ to: "test@example.com", subject: "Test", templateId: "test", parameters: {} }) }, 
+          headers: {} 
+        }
+      })
+    }
+  };
+});
 
 describe("retry queue", () => {
 
@@ -24,7 +63,7 @@ describe("retry queue", () => {
   };
 
   const sentMessageMock = (a: number): SentMessageInfo => { return {
-    /** an envelope object {from:‘address’, to:[‘address’]} */
+    /** an envelope object {from:'address', to:['address']} */
     envelope: {from: "testFrom", to: ["testTo"]} as Envelope,
     /** the Message-ID header value. This value is derived from the response of SES API, so it differs from the Message-ID values used in logging. */
     messageId: ("sentMessageId "+a),
@@ -67,6 +106,12 @@ describe("retry queue", () => {
 
   retryQueueClient.deleteMessage = mockDeleteMessage;
 
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Mock retryQueueClient.sendMessage if not already mocked
+    retryQueueClient.sendMessage = jest.fn().mockResolvedValue({});
+  });
+
   it("sendMessageToRetryQueue", async () => {
     jest.spyOn(fs.promises, 'readFile').mockImplementation(mockLoadTemplate);
 
@@ -105,8 +150,7 @@ describe("retry queue", () => {
 
     const spySendMail = jest.spyOn(mailTrasporterMock,'sendMail');
     retryQueueClient.createIfNotExists();
-    const spyDecrypt = jest.spyOn(apiPdvClient, 'findPiiUsingGET').mockResolvedValue({_tag: "Right", right:{ status:200 , value: {pii: JSON.stringify(requestMock.body)}, headers: "" as any} });
-
+    
     addRetryQueueListener(config,mailTrasporterMock);
 
     expect(setInterval).toHaveBeenCalledTimes(1);
@@ -144,8 +188,7 @@ describe("retry queue", () => {
     } as unknown as Transporter<SentMessageInfo>;
     const spySendMail = jest.spyOn(mailTrasporterMock,'sendMail');
     retryQueueClient.createIfNotExists();
-    const spyDecrypt = jest.spyOn(apiPdvClient, 'findPiiUsingGET').mockResolvedValue({_tag: "Right", right:{ status: 400 , value: { status: 400, title: ""}, headers: "" as any} });
-
+    
     addRetryQueueListener(config, mailTrasporterMock);
 
     expect(setInterval).toHaveBeenCalledTimes(1);
@@ -155,5 +198,160 @@ describe("retry queue", () => {
     expect(mockReceiveMessages).toHaveBeenCalledTimes(1);
 
     jest.useRealTimers();
+  });
+
+  // New tests for retry mechanism
+  describe("Email Retry Mechanism Tests", () => {
+    describe("writeMessageIntoQueue", () => {
+      const mockConfig = {
+        MAX_RETRY_ATTEMPTS: 3,
+        INITIAL_RETRY_TIMEOUT_SECONDS: 60
+      };
+
+      it("should enqueue message with correct retry count when retryCount > 0", () => {
+        const bodyEncrypted = "encrypted-body";
+        const clientId = "test-client";
+        const retryCount = 2;
+
+        writeMessageIntoQueue(bodyEncrypted, clientId, retryCount, mockConfig as any);
+
+        expect(logger.info).toHaveBeenCalledWith(
+          `Enqueueing failed message with retryCount ${retryCount}`
+        );
+        expect(retryQueueClient.sendMessage).toHaveBeenCalledWith(
+          JSON.stringify({
+            clientId,
+            bodyEncrypted,
+            retryCount
+          }),
+          {
+            visibilityTimeout: 
+              2 ** (mockConfig.MAX_RETRY_ATTEMPTS - retryCount) * 
+              mockConfig.INITIAL_RETRY_TIMEOUT_SECONDS
+          }
+        );
+        expect(sendMessageToErrorQueue).not.toHaveBeenCalled();
+      });
+
+      it("should send message to error queue when retryCount is 0", () => {
+        const bodyEncrypted = "encrypted-body";
+        const clientId = "test-client";
+        const retryCount = 0;
+
+        writeMessageIntoQueue(bodyEncrypted, clientId, retryCount, mockConfig as any);
+
+        expect(logger.error).toHaveBeenCalledWith(
+          "Message failed too many times, adding to error queue"
+        );
+        expect(sendMessageToErrorQueue).toHaveBeenCalledWith(bodyEncrypted, clientId);
+        expect(retryQueueClient.sendMessage).not.toHaveBeenCalled();
+      });
+
+      it("should calculate correct visibility timeout based on retry count", () => {
+        const bodyEncrypted = "encrypted-body";
+        const clientId = "test-client";
+        
+        // Test with different retry counts
+        [3, 2, 1].forEach(retryCount => {
+          jest.clearAllMocks();
+          
+          writeMessageIntoQueue(bodyEncrypted, clientId, retryCount, mockConfig as any);
+          
+          const expectedTimeout = 
+            2 ** (mockConfig.MAX_RETRY_ATTEMPTS - retryCount) * 
+            mockConfig.INITIAL_RETRY_TIMEOUT_SECONDS;
+          
+          expect(retryQueueClient.sendMessage).toHaveBeenCalledWith(
+            expect.any(String),
+            { visibilityTimeout: expectedTimeout }
+          );
+        });
+      });
+    });
+
+    describe("sendEmail retry mechanism", () => {
+      // Mock dependencies for sendEmail tests
+      const mockMailTransporter: Partial<Transporter<SentMessageInfo>> = {
+        sendMail: jest.fn()
+      };
+      
+      const mockConfig = {
+        ECOMMERCE_NOTIFICATIONS_SENDER: "test@example.com",
+        MAX_RETRY_ATTEMPTS: 3,
+        INITIAL_RETRY_TIMEOUT_SECONDS: 60,
+        PAGOPA_MAIL_LOGO_URI: "https://example.com/logo.png"
+      };
+      
+      const mockTemplateCache = {
+        getTemplates: jest.fn().mockResolvedValue({
+          htmlTemplate: (params: any) => `<p>Test HTML with ${JSON.stringify(params)}</p>`,
+          textTemplate: (params: any) => `Test text with ${JSON.stringify(params)}</p>`,
+        })
+      };
+      
+      // Create a mock Type object that satisfies the io-ts Type interface
+      const mockSchema = {
+        default: {
+          decode: jest.fn().mockImplementation(params => E.right(params)),
+        }
+      };
+      
+      const mockParams = {
+        "X-Client-Id": "TEST_CLIENT",
+        body: {
+          templateId: "test-template",
+          to: "recipient@example.com",
+          subject: "Test Subject",
+          parameters: { name: "Test User" }
+        }
+      } as any;
+
+      it("should handle AWS SES error and retry with encrypted body", async () => {
+        // Mock sendMail to throw an error
+        (mockMailTransporter.sendMail as jest.Mock).mockRejectedValueOnce(
+          new Error("AWS SES Error")
+        );
+        
+        await sendEmail(
+          mockParams,
+          mockSchema as any,
+          mockMailTransporter as any,
+          mockConfig as any,
+          mockConfig.MAX_RETRY_ATTEMPTS,
+          mockTemplateCache as any
+        );
+        
+        // Verify error was logged
+        expect(logger.error).toHaveBeenCalledWith(
+          expect.stringContaining("Error while trying to send email to AWS SES")
+        );
+        
+        // Verify message was queued with correct parameters
+        expect(retryQueueClient.sendMessage).toHaveBeenCalled();
+        
+        // Check that the first argument to sendMessage contains the client ID
+        const sendMessageArgs = (retryQueueClient.sendMessage as jest.Mock).mock.calls[0][0];
+        expect(sendMessageArgs).toContain(mockParams["X-Client-Id"]);
+      });
+
+      it("should return ResponseSuccessAccepted when email sending fails and is queued for retry", async () => {
+        // Mock sendMail to throw an error
+        (mockMailTransporter.sendMail as jest.Mock).mockRejectedValueOnce(
+          new Error("AWS SES Error")
+        );
+        
+        const result = await sendEmail(
+          mockParams,
+          mockSchema as any,
+          mockMailTransporter as any,
+          mockConfig as any,
+          mockConfig.MAX_RETRY_ATTEMPTS,
+          mockTemplateCache as any
+        );
+        
+        // Should return accepted response
+        expect(result.kind).toBe("IResponseSuccessAccepted");
+      });
+    });
   });
 });

--- a/src/__tests__/templateCache.test.ts
+++ b/src/__tests__/templateCache.test.ts
@@ -1,0 +1,242 @@
+import * as fs from "fs";
+import * as Handlebars from "handlebars";
+import { createTemplateCache, ITemplateCache } from "../../src/util/templateCache";
+import { logger } from "../../src/util/logger";
+
+type MockedFunction<T extends (...args: any[]) => any> = jest.Mock<ReturnType<T>, Parameters<T>>;
+
+// Mock loggers
+jest.mock("../../src/util/logger", () => ({
+  logger: {
+    info: jest.fn(),
+    error: jest.fn()
+  }
+}));
+
+// Mock handlebars
+jest.mock("handlebars", () => ({
+  compile: jest.fn()
+}));
+
+// Mock fs
+jest.mock("fs", () => ({
+  promises: {
+    readFile: jest.fn()
+  }
+}));
+
+// Get typed mocks
+const mockedReadFile = fs.promises.readFile as MockedFunction<typeof fs.promises.readFile>;
+const mockedCompile = Handlebars.compile as MockedFunction<typeof Handlebars.compile>;
+
+describe("templateCache", () => {
+  const mockTemplateId = "test-template";
+  const mockTextContent = "This is a text template for {{ name }}";
+  const mockHtmlContent = "<div>This is an HTML template for {{ name }}</div>";
+  const mockCompiledTextTemplate = jest.fn((data) => `Text for ${data.name}`);
+  const mockCompiledHtmlTemplate = jest.fn((data) => `<div>HTML for ${data.name}</div>`);
+  
+  let templateCache: ITemplateCache;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    
+    // Setup read file mock
+    mockedReadFile.mockImplementation((path: any) => {
+      if (typeof path === 'string') {
+        if (path.includes(".txt")) {
+          return Promise.resolve(mockTextContent);
+        }
+        if (path.includes(".html")) {
+          return Promise.resolve(mockHtmlContent);
+        }
+      }
+      return Promise.reject(new Error("File not found"));
+    });
+    
+    mockedCompile.mockImplementation((source: any) => {
+      if (source === mockTextContent) {
+        return mockCompiledTextTemplate;
+      }
+      if (source === mockHtmlContent) {
+        return mockCompiledHtmlTemplate;
+      }
+      return jest.fn();
+    });
+    
+    // Create a fresh template cache for each test
+    templateCache = createTemplateCache();
+  });
+
+  describe("getTemplates", () => {
+    it("should compile and cache templates on first request", async () => {
+      const result = await templateCache.getTemplates(mockTemplateId);
+
+      expect(mockedReadFile).toHaveBeenCalledTimes(2);
+      expect(mockedReadFile).toHaveBeenCalledWith(
+        `./dist/src/templates/${mockTemplateId}/${mockTemplateId}.template.txt`,
+        "utf-8"
+      );
+      expect(mockedReadFile).toHaveBeenCalledWith(
+        `./dist/src/templates/${mockTemplateId}/${mockTemplateId}.template.html`,
+        "utf-8"
+      );
+      
+      expect(mockedCompile).toHaveBeenCalledTimes(2);
+      expect(mockedCompile).toHaveBeenCalledWith(mockTextContent);
+      expect(mockedCompile).toHaveBeenCalledWith(mockHtmlContent);
+      
+      expect(logger.info).toHaveBeenCalledWith(`Compiling template for ${mockTemplateId}`);
+      
+      expect(result).toEqual({
+        textTemplate: mockCompiledTextTemplate,
+        htmlTemplate: mockCompiledHtmlTemplate
+      });
+    });
+
+    it("should return cached templates on subsequent requests", async () => {
+      // First call to cache the templates
+      await templateCache.getTemplates(mockTemplateId);
+      
+      // Reset mocks to verify they're not called again
+      jest.clearAllMocks();
+      
+      // Execute second call
+      const result = await templateCache.getTemplates(mockTemplateId);
+      
+      // Verify
+      expect(mockedReadFile).not.toHaveBeenCalled();
+      expect(mockedCompile).not.toHaveBeenCalled();
+      expect(logger.info).toHaveBeenCalledWith(`Using cached template for ${mockTemplateId}`);
+      
+      expect(result).toEqual({
+        textTemplate: mockCompiledTextTemplate,
+        htmlTemplate: mockCompiledHtmlTemplate
+      });
+    });
+
+    it("should handle file read errors properly", async () => {
+      // Setup mock to throw an error
+      mockedReadFile.mockRejectedValueOnce(new Error("File read error"));
+      
+      await expect(templateCache.getTemplates(mockTemplateId)).rejects.toThrow("File read error");
+      
+      expect(logger.error).toHaveBeenCalledWith(expect.stringContaining("Error reading or compiling templates"));
+    });
+
+    it("should handle template compilation errors", async () => {
+      // Setup mock to throw an error during compilation
+      mockedCompile.mockImplementationOnce(() => {
+        throw new Error("Compilation error");
+      });
+      
+      await expect(templateCache.getTemplates(mockTemplateId)).rejects.toThrow("Compilation error");
+
+      expect(logger.error).toHaveBeenCalledWith(expect.stringContaining("Error reading or compiling templates"));
+    });
+  });
+
+  describe("clearCache", () => {
+    it("should clear all cached templates", async () => {
+      // First cache some templates
+      await templateCache.getTemplates(mockTemplateId);
+      
+      // Mock a second template
+      const anotherTemplateId = "another-template";
+      mockedReadFile.mockImplementation((path: any) => {
+        if (typeof path === 'string') {
+          if (path.includes(anotherTemplateId) && path.includes(".txt")) {
+            return Promise.resolve("Another text template");
+          }
+          if (path.includes(anotherTemplateId) && path.includes(".html")) {
+            return Promise.resolve("Another HTML template");
+          }
+          if (path.includes(mockTemplateId) && path.includes(".txt")) {
+            return Promise.resolve(mockTextContent);
+          }
+          if (path.includes(mockTemplateId) && path.includes(".html")) {
+            return Promise.resolve(mockHtmlContent);
+          }
+        }
+        return Promise.reject(new Error("File not found"));
+      });
+      
+      await templateCache.getTemplates(anotherTemplateId);
+      
+      // Verify cache size
+      expect(templateCache.getCacheSize()).toBe(2);
+      
+      // Clear cache
+      templateCache.clearCache();
+      
+      // Verify cache is empty
+      expect(templateCache.getCacheSize()).toBe(0);
+      expect(logger.info).toHaveBeenCalledWith("Template cache cleared");
+      
+      // Verify templates are recompiled after clearing
+      jest.clearAllMocks();
+      await templateCache.getTemplates(mockTemplateId);
+      expect(mockedReadFile).toHaveBeenCalledTimes(2);
+      expect(mockedCompile).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("getCacheSize", () => {
+    it("should return the correct number of cached templates", async () => {
+      // Initially empty
+      expect(templateCache.getCacheSize()).toBe(0);
+      
+      // Cache one template
+      await templateCache.getTemplates(mockTemplateId);
+      expect(templateCache.getCacheSize()).toBe(1);
+      
+      // Mock a second template
+      const anotherTemplateId = "another-template";
+      mockedReadFile.mockImplementation((path: any) => {
+        if (typeof path === 'string') {
+          if (path.includes(anotherTemplateId) && path.includes(".txt")) {
+            return Promise.resolve("Another text template");
+          }
+          if (path.includes(anotherTemplateId) && path.includes(".html")) {
+            return Promise.resolve("Another HTML template");
+          }
+          if (path.includes(mockTemplateId) && path.includes(".txt")) {
+            return Promise.resolve(mockTextContent);
+          }
+          if (path.includes(mockTemplateId) && path.includes(".html")) {
+            return Promise.resolve(mockHtmlContent);
+          }
+        }
+        return Promise.reject(new Error("File not found"));
+      });
+      
+      // Cache another template
+      await templateCache.getTemplates(anotherTemplateId);
+      expect(templateCache.getCacheSize()).toBe(2);
+      
+      // Clear and verify
+      templateCache.clearCache();
+      expect(templateCache.getCacheSize()).toBe(0);
+    });
+  });
+
+  describe("template rendering", () => {
+    it("should correctly render templates with provided data", async () => {
+      // Get the templates
+      const templates = await templateCache.getTemplates(mockTemplateId);
+      
+      // Test data
+      const testData = { name: "Test PagoPA" };
+      
+      // Render templates
+      const textResult = templates.textTemplate(testData);
+      const htmlResult = templates.htmlTemplate(testData);
+      
+      // Verify rendering
+      expect(mockCompiledTextTemplate).toHaveBeenCalledWith(testData);
+      expect(mockCompiledHtmlTemplate).toHaveBeenCalledWith(testData);
+      expect(textResult).toBe("Text for Test PagoPA");
+      expect(htmlResult).toBe("<div>HTML for Test PagoPA</div>");
+    });
+  });
+});

--- a/src/__tests__/templateCache.test.ts
+++ b/src/__tests__/templateCache.test.ts
@@ -86,8 +86,6 @@ describe("templateCache", () => {
       expect(mockedCompile).toHaveBeenCalledWith(mockTextContent);
       expect(mockedCompile).toHaveBeenCalledWith(mockHtmlContent);
       
-      expect(logger.info).toHaveBeenCalledWith(`Compiling template for ${mockTemplateId}`);
-      
       expect(result).toEqual({
         textTemplate: mockCompiledTextTemplate,
         htmlTemplate: mockCompiledHtmlTemplate
@@ -107,7 +105,6 @@ describe("templateCache", () => {
       // Verify
       expect(mockedReadFile).not.toHaveBeenCalled();
       expect(mockedCompile).not.toHaveBeenCalled();
-      expect(logger.info).toHaveBeenCalledWith(`Using cached template for ${mockTemplateId}`);
       
       expect(result).toEqual({
         textTemplate: mockCompiledTextTemplate,

--- a/src/controllers/EmailsControllers.ts
+++ b/src/controllers/EmailsControllers.ts
@@ -65,25 +65,25 @@ const sendEmailWithAWS = async (
   return messageInfoOk;
 };
 
-type TemplateResult = {
-  textTemplate: Handlebars.TemplateDelegate;
-  htmlTemplate: Handlebars.TemplateDelegate;
+interface ITemplateResult {
+  readonly textTemplate: Handlebars.TemplateDelegate;
+  readonly htmlTemplate: Handlebars.TemplateDelegate;
 }
 
-const loadTemplates = async (templateId: string): Promise<TemplateResult> => {
+const loadTemplates = async (templateId: string): Promise<ITemplateResult> => {
   try {
     // Load both templates in parallel
     const [textTemplateRaw, htmlTemplateRaw] = await Promise.all([
       fs.promises.readFile(
-        `./dist/src/templates/${templateId}/${templateId}.template.txt`, 
+        `./dist/src/templates/${templateId}/${templateId}.template.txt`,
         "utf8"
       ),
       fs.promises.readFile(
-        `./dist/src/templates/${templateId}/${templateId}.template.html`, 
+        `./dist/src/templates/${templateId}/${templateId}.template.html`,
         "utf8"
       )
     ]);
-    
+
     // Compile the templates
     return {
       textTemplate: Handlebars.compile(textTemplateRaw),
@@ -147,7 +147,7 @@ export const sendEmail = async (
   const clientId = params["X-Client-Id"];
 
   const templateId = params.body.templateId;
-  
+
   const { textTemplate, htmlTemplate } = await loadTemplates(templateId);
 
   // add pagopa logo URI taken from configuration

--- a/src/controllers/__tests__/EmailsControllers.test.ts
+++ b/src/controllers/__tests__/EmailsControllers.test.ts
@@ -173,7 +173,8 @@ describe("mail controller", () => {
 
 });
 
-// Move to a new describe block
+// template-reated errors section.
+// Moved to a new describe block to optimize mocking
 describe("template error handling", () => {
   beforeAll(async () => {
     registerHelpers();

--- a/src/controllers/__tests__/EmailsControllers.test.ts
+++ b/src/controllers/__tests__/EmailsControllers.test.ts
@@ -8,11 +8,12 @@ import registerHelpers from "handlebars-helpers";
 import { mockReq } from "../../__mocks__/data_mock";
 import * as fs from "fs";
 import { logger } from "../../util/logger";
+import * as templateCacheModule from "../../util/templateCache";
   
 var config = getConfigOrThrow();
 
 const sentMessage = {
-  /** an envelope object {from:‘address’, to:[‘address’]} */
+  /** an envelope object {from:'address', to:['address']} */
   envelope: {from: "testFrom", to: ["testTo"]} as Envelope,
   /** the Message-ID header value. This value is derived from the response of SES API, so it differs from the Message-ID values used in logging. */
   messageId: "messageId",
@@ -57,6 +58,25 @@ describe("mail controller", () => {
 
     beforeEach(async () => {
       jest.useFakeTimers();
+      // Create mock template functions
+      const mockTextTemplate = jest.fn((data) => `Text template with ${JSON.stringify(data)}`);
+      const mockHtmlTemplate = jest.fn((data) => `<html>HTML template with ${JSON.stringify(data)}</html>`);
+      
+      // Mock the getTemplates function to return our mock templates
+      const mockGetTemplates = jest.fn().mockResolvedValue({
+        textTemplate: mockTextTemplate,
+        htmlTemplate: mockHtmlTemplate
+      });
+      
+      // Create a mock template cache object
+      const mockTemplateCache = {
+        getTemplates: mockGetTemplates,
+        clearCache: jest.fn(),
+        getCacheSize: jest.fn(() => 0)
+      };
+      
+      // Replace the createTemplateCache function
+      jest.spyOn(templateCacheModule, 'createTemplateCache').mockImplementation(() => mockTemplateCache);
       jest.spyOn(global, 'setInterval');
     });
 
@@ -123,38 +143,6 @@ describe("mail controller", () => {
       expect(responseErrorValidation.kind).toBe("IResponseSuccessJson");
     });
 
-    it("should return ResponseErrorValidation when template files cannot be read", async () => {
-      // Mock fs.promises.readFile to throw an error
-      const fsReadFileMock = jest.spyOn(fs.promises, "readFile").mockImplementation(() => {
-        throw new Error("File not found");
-      });
-    
-      const loggerErrorMock = jest.spyOn(logger, "error").mockImplementation(jest.fn());
-    
-      // Create a valid request with proper client ID and template ID
-      const request = getReq("success", "CLIENT_ECOMMERCE");
-
-      const handler = sendMail(config, getMailTransporterMock());
-      
-      const response = await handler(request);
-    
-      expect(response.kind).toBe("IResponseErrorValidation");
-      
-      // Type guard to check if response is IResponseErrorValidation
-      if (response.kind === "IResponseErrorValidation") {
-        expect(response.detail).toBe("Template Error: Failed to load templates");
-      }
-    
-      // Verify logger.error was called with the error message
-      expect(logger.error).toHaveBeenCalledWith(
-        expect.stringContaining("Error reading templates: Error: File not found")
-      );
-    
-      // Clean up mocks
-      fsReadFileMock.mockRestore();
-      loggerErrorMock.mockRestore();
-    });
-
     xit("should catch error and return none", async () => {
 
       const sentMessageMock = {
@@ -183,6 +171,65 @@ describe("mail controller", () => {
     expect(response.kind).toBe("IResponseSuccessJson");
   });
 
+});
+
+// Move to a new describe block
+describe("template error handling", () => {
+  beforeAll(async () => {
+    registerHelpers();
+  });
+
+  afterEach(async () => {
+    jest.useRealTimers();
+    jest.resetAllMocks();
+    jest.restoreAllMocks();
+  });
+
+  beforeEach(async () => {
+    jest.useFakeTimers();
+    jest.spyOn(global, 'setInterval');
+  });
+  
+  it("should return ResponseErrorValidation when template files cannot be read", async () => {
+    // Mock the createTemplateCache function to return a cache that throws an error
+    const errorMock = new Error("File not found");
+    const mockTemplateCache = {
+      getTemplates: jest.fn().mockRejectedValue(errorMock),
+      clearCache: jest.fn(),
+      getCacheSize: jest.fn(() => 0),
+    };
+
+    // Spy on the createTemplateCache function and replace its implementation
+    jest.spyOn(templateCacheModule, "createTemplateCache").mockReturnValue(mockTemplateCache);
+
+    // Mock the logger to verify error logging
+    const loggerErrorMock = jest.spyOn(logger, "error").mockImplementation(jest.fn());
+
+    const { sendMail } = require("../EmailsControllers");
+    
+      // Create a valid request with proper client ID and template ID
+      const request = getReq("success", "CLIENT_ECOMMERCE");
+
+      const handler = sendMail(config, getMailTransporterMock());
+      
+      const response = await handler(request);
+    
+      expect(response.kind).toBe("IResponseErrorValidation");
+      
+      // Type guard to check if response is IResponseErrorValidation
+      if (response.kind === "IResponseErrorValidation") {
+        expect(response.detail).toBe("Template Error: Failed to load templates");
+      }
+    
+    
+      // Verify that logger.error was called with the correct error message
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining("Error reading templates: Error: File not found")
+      );
+
+      // Restore mocks after test
+      jest.restoreAllMocks();
+    });
 });
 
 describe("test template", () => {

--- a/src/controllers/__tests__/EmailsControllers.test.ts
+++ b/src/controllers/__tests__/EmailsControllers.test.ts
@@ -203,34 +203,34 @@ describe("template error handling", () => {
     // Spy on the createTemplateCache function and replace its implementation
     jest.spyOn(templateCacheModule, "createTemplateCache").mockReturnValue(mockTemplateCache);
 
-      // Mock the logger to verify error logging
-      const loggerErrorMock = jest.spyOn(logger, "error").mockImplementation(jest.fn());
+    // Mock the logger to verify error logging
+    const loggerErrorMock = jest.spyOn(logger, "error").mockImplementation(jest.fn());
 
-      const { sendMail } = require("../EmailsControllers");
-    
-      // Create a valid request with proper client ID and template ID
-      const request = getReq("success", "CLIENT_ECOMMERCE");
+    const { sendMail } = require("../EmailsControllers");
+  
+    // Create a valid request with proper client ID and template ID
+    const request = getReq("success", "CLIENT_ECOMMERCE");
 
-      const handler = sendMail(config, getMailTransporterMock());
-      
-      const response = await handler(request);
+    const handler = sendMail(config, getMailTransporterMock());
     
-      expect(response.kind).toBe("IResponseErrorValidation");
-      
-      // Type guard to check if response is IResponseErrorValidation
-      if (response.kind === "IResponseErrorValidation") {
-        expect(response.detail).toBe("Template Error: Failed to load templates");
-      }
+    const response = await handler(request);
+  
+    expect(response.kind).toBe("IResponseErrorValidation");
     
-    
-      // Verify that logger.error was called with the correct error message
-      expect(logger.error).toHaveBeenCalledWith(
-        expect.stringContaining("Error reading templates: Error: File not found")
-      );
+    // Type guard to check if response is IResponseErrorValidation
+    if (response.kind === "IResponseErrorValidation") {
+      expect(response.detail).toBe("Template Error: Failed to load templates");
+    }
+  
+  
+    // Verify that logger.error was called with the correct error message
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining("Error reading templates: Error: File not found")
+    );
 
-      // Restore mocks after test
-      jest.restoreAllMocks();
-    });
+    // Restore mocks after test
+    jest.restoreAllMocks();
+  });
 });
 
 describe("test template", () => {

--- a/src/controllers/__tests__/EmailsControllers.test.ts
+++ b/src/controllers/__tests__/EmailsControllers.test.ts
@@ -203,10 +203,10 @@ describe("template error handling", () => {
     // Spy on the createTemplateCache function and replace its implementation
     jest.spyOn(templateCacheModule, "createTemplateCache").mockReturnValue(mockTemplateCache);
 
-    // Mock the logger to verify error logging
-    const loggerErrorMock = jest.spyOn(logger, "error").mockImplementation(jest.fn());
+      // Mock the logger to verify error logging
+      const loggerErrorMock = jest.spyOn(logger, "error").mockImplementation(jest.fn());
 
-    const { sendMail } = require("../EmailsControllers");
+      const { sendMail } = require("../EmailsControllers");
     
       // Create a valid request with proper client ID and template ID
       const request = getReq("success", "CLIENT_ECOMMERCE");
@@ -274,10 +274,10 @@ const getReq = (templateId: string, header: string | undefined) => {
   return {
     header: (s: string) => header,
     body: {
-     to: "to@email.it",
-     subject: "subjectTest",
-     templateId: templateId,
-     parameters: mockReq},
-     lang: {language: "IT" }
-   } as any;
+      to: "to@email.it",
+      subject: "subjectTest",
+      templateId: templateId,
+      parameters: mockReq},
+      lang: {language: "IT" }
+  } as any;
 }

--- a/src/queues/RetryQueueListener.ts
+++ b/src/queues/RetryQueueListener.ts
@@ -12,11 +12,15 @@ import { logger } from "../util/logger";
 import { retryQueueClient } from "../util/queues";
 import { IConfig } from "../util/config";
 import { NotificationEmailRequest } from "../generated/definitions/NotificationEmailRequest";
+import { createTemplateCache } from "../util/templateCache";
 
 export const addRetryQueueListener = (
   config: IConfig,
   mailTrasporter: Transporter<SESTransport.SentMessageInfo>
 ): void => {
+  // Create the template cache when the listener is initialized
+  const templateCache = createTemplateCache();
+
   const retrieveMessage = async (): Promise<void> => {
     try {
       const messages = await retryQueueClient.receiveMessages({
@@ -70,7 +74,8 @@ export const addRetryQueueListener = (
                     schema,
                     mailTrasporter,
                     config,
-                    retryCount - 1
+                    retryCount - 1,
+                    templateCache
                   );
                 }
               )

--- a/src/util/templateCache.ts
+++ b/src/util/templateCache.ts
@@ -58,11 +58,8 @@ export const createTemplateCache = (): ITemplateCache => {
     }> => {
       // Return from cache if available
       if (templateCache[templateId]) {
-        logger.info(`Using cached template for ${templateId}`);
         return templateCache[templateId];
       }
-
-      logger.info(`Compiling template for ${templateId}`);
 
       try {
         // Read templates asynchronously

--- a/src/util/templateCache.ts
+++ b/src/util/templateCache.ts
@@ -1,0 +1,100 @@
+import * as fs from "fs";
+import * as Handlebars from "handlebars";
+import { logger } from "./logger";
+
+export interface ITemplateCache {
+  readonly getTemplates: (
+    templateId: string
+  ) => Promise<{
+    readonly textTemplate: Handlebars.TemplateDelegate;
+    readonly htmlTemplate: Handlebars.TemplateDelegate;
+  }>;
+  readonly clearCache: () => void;
+  readonly getCacheSize: () => number;
+}
+
+// Template cache factory function
+export const createTemplateCache = (): ITemplateCache => {
+  // Private cache object inside closure
+  const templateCache: Record<
+    string,
+    {
+      readonly textTemplate: Handlebars.TemplateDelegate;
+      readonly htmlTemplate: Handlebars.TemplateDelegate;
+    }
+  > = {};
+
+  return {
+    /**
+     * Clears the template cache
+     */
+    clearCache: (): void => {
+      // Create a new array of keys to avoid modifying during iteration
+      const keys = Object.keys(templateCache);
+      // Use forEach with immutable approach
+      keys.forEach(key => {
+        // eslint-disable-next-line fp/no-delete, functional/immutable-data
+        delete templateCache[key];
+      });
+      logger.info("Template cache cleared");
+    },
+
+    /**
+     * Gets the current size of the template cache
+     */
+    getCacheSize: (): number => Object.keys(templateCache).length,
+
+    /**
+     * Gets or compiles templates for a given templateId
+     *
+     * @param templateId The ID of the template to get/compile
+     * @returns Promise with compiled text and HTML templates
+     */
+    getTemplates: async (
+      templateId: string
+    ): Promise<{
+      readonly textTemplate: Handlebars.TemplateDelegate;
+      readonly htmlTemplate: Handlebars.TemplateDelegate;
+    }> => {
+      // Return from cache if available
+      if (templateCache[templateId]) {
+        logger.info(`Using cached template for ${templateId}`);
+        return templateCache[templateId];
+      }
+
+      logger.info(`Compiling template for ${templateId}`);
+
+      try {
+        // Read templates asynchronously
+        const [textTemplateRaw, htmlTemplateRaw] = await Promise.all([
+          fs.promises.readFile(
+            `./dist/src/templates/${templateId}/${templateId}.template.txt`,
+            "utf-8"
+          ),
+          fs.promises.readFile(
+            `./dist/src/templates/${templateId}/${templateId}.template.html`,
+            "utf-8"
+          )
+        ]);
+
+        // Compile templates
+        const textTemplate = Handlebars.compile(textTemplateRaw);
+        const htmlTemplate = Handlebars.compile(htmlTemplateRaw);
+
+        // Cache the compiled templates - using an immutable approach
+        const newTemplate = {
+          htmlTemplate,
+          textTemplate
+        };
+
+        // eslint-disable-next-line functional/immutable-data
+        templateCache[templateId] = newTemplate;
+
+        return newTemplate;
+      } catch (error) {
+        logger.error(`Error reading or compiling templates: ${error}`);
+        throw error;
+      }
+    }
+  };
+};


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

In this PR we load templates asynchronously and we introduce a caching system.

#### List of Changes
- load templates asynchronously
- cache templates compilation
- Modified jest configuration to avoid:
```
jest-haste-map: duplicate manual mock found: data_mock
  The following files share their name; please delete one of them:
    * <rootDir>/src/__mocks__/data_mock.ts
    * <rootDir>/dist/src/__mocks__/data_mock.js

jest-haste-map: Haste module naming collision: pagopa-notifications-service
  The following files share their name; please adjust your hasteImpl:
    * <rootDir>/package.json
    * <rootDir>/dist/package.json
```

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The changes introduced with this PR want to improve the overall performance by avoiding blocking requests and introducing template compilation caching.
With the PR implementation, compiled templates keep a constant memory, while the per-request approach reads and compiles templates each time they're needed.
For example, assuming the success template is 30KB when compiled (in reality should be around 1KB), with 10 requests per second (in production we're around 6-7 rps), the per-request approach would compile the template separately for each request: 10 × 30KB = 300KB total memory usage. But when the template is compiled once and reused, the memory used memory is just the size of a single template (90% less). And that's if we assume that the GC frees the memory hold by the per-request template very fast.
Additionally, this change eliminates the overhead of reading files from the filesystem for each request, and the  Handlebars compilation each time.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

localhost, dev

#### Screenshots (if appropriate):
Pod logs (highlight on the compilation and cached results):
```
{"@timestamp":"2025-04-01T12:39:25.212Z","ecs.version":"8.10.0","event.dataset":"pagopa-notifications-service","log.level":"info","message":"Compiling template for poc-1","service.environment":"dev","service.name":"pagopa-notifications-service","service.version":"1.10.0","span_id":"4184b44fb0d6257f","trace_flags":"01","trace_id":"04efdfeb1e259d545d43408fd33d7920"}
{"@timestamp":"2025-04-01T12:39:25.319Z","ecs.version":"8.10.0","event.dataset":"pagopa-notifications-service","log.level":"info","message":"[CLIENT_ECOMMERCE] - Sending email with template poc-1","service.environment":"dev","service.name":"pagopa-notifications-service","service.version":"1.10.0","span_id":"4184b44fb0d6257f","trace_flags":"01","trace_id":"04efdfeb1e259d545d43408fd33d7920"}
{"@timestamp":"2025-04-01T12:39:25.877Z","ecs.version":"8.10.0","event.dataset":"pagopa-notifications-service","log.level":"info","message":"Message sent with ID <01150195f15d1b35-b60c6c5c-7739-41b3-8496-b982272221a7-000000@eu-south-1.amazonses.com>","service.environment":"dev","service.name":"pagopa-notifications-service","service.version":"1.10.0","span_id":"4184b44fb0d6257f","trace_flags":"01","trace_id":"04efdfeb1e259d545d43408fd33d7920"}
{"@timestamp":"2025-04-01T12:46:36.279Z","ecs.version":"8.10.0","event.dataset":"pagopa-notifications-service","log.level":"info","message":"Compiling template for success","service.environment":"dev","service.name":"pagopa-notifications-service","service.version":"1.10.0","span_id":"6b1024f174fbef57","trace_flags":"01","trace_id":"c3175404759045c751d2d3879877ce2d"}
{"@timestamp":"2025-04-01T12:46:37.010Z","ecs.version":"8.10.0","event.dataset":"pagopa-notifications-service","log.level":"info","message":"[CLIENT_ECOMMERCE] - Sending email with template success","service.environment":"dev","service.name":"pagopa-notifications-service","service.version":"1.10.0","span_id":"6b1024f174fbef57","trace_flags":"01","trace_id":"c3175404759045c751d2d3879877ce2d"}
{"@timestamp":"2025-04-01T12:46:38.316Z","ecs.version":"8.10.0","event.dataset":"pagopa-notifications-service","log.level":"info","message":"Message sent with ID <01150195f163b45f-6c8a488e-4853-45a8-a655-ab9246e68eaa-000000@eu-south-1.amazonses.com>","service.environment":"dev","service.name":"pagopa-notifications-service","service.version":"1.10.0","span_id":"6b1024f174fbef57","trace_flags":"01","trace_id":"c3175404759045c751d2d3879877ce2d"}
{"@timestamp":"2025-04-01T12:48:10.599Z","ecs.version":"8.10.0","event.dataset":"pagopa-notifications-service","log.level":"info","message":"Compiling template for ko","service.environment":"dev","service.name":"pagopa-notifications-service","service.version":"1.10.0","span_id":"6728d72405cce90e","trace_flags":"01","trace_id":"c3175404759045c751d2d3879877ce2d"}
{"@timestamp":"2025-04-01T12:48:10.605Z","ecs.version":"8.10.0","event.dataset":"pagopa-notifications-service","log.level":"info","message":"[CLIENT_ECOMMERCE] - Sending email with template ko","service.environment":"dev","service.name":"pagopa-notifications-service","service.version":"1.10.0","span_id":"6728d72405cce90e","trace_flags":"01","trace_id":"c3175404759045c751d2d3879877ce2d"}
{"@timestamp":"2025-04-01T12:48:10.927Z","ecs.version":"8.10.0","event.dataset":"pagopa-notifications-service","log.level":"info","message":"Message sent with ID <01150195f1651e56-c7d94231-26e4-4102-ad28-52e0b3584067-000000@eu-south-1.amazonses.com>","service.environment":"dev","service.name":"pagopa-notifications-service","service.version":"1.10.0","span_id":"6728d72405cce90e","trace_flags":"01","trace_id":"c3175404759045c751d2d3879877ce2d"}
{"@timestamp":"2025-04-01T12:49:21.851Z","ecs.version":"8.10.0","event.dataset":"pagopa-notifications-service","log.level":"info","message":"Using cached template for success","service.environment":"dev","service.name":"pagopa-notifications-service","service.version":"1.10.0","span_id":"a3bd93c226e95283","trace_flags":"01","trace_id":"c3175404759045c751d2d3879877ce2d"}
{"@timestamp":"2025-04-01T12:49:21.854Z","ecs.version":"8.10.0","event.dataset":"pagopa-notifications-service","log.level":"info","message":"[CLIENT_ECOMMERCE] - Sending email with template success","service.environment":"dev","service.name":"pagopa-notifications-service","service.version":"1.10.0","span_id":"a3bd93c226e95283","trace_flags":"01","trace_id":"c3175404759045c751d2d3879877ce2d"}
{"@timestamp":"2025-04-01T12:49:22.455Z","ecs.version":"8.10.0","event.dataset":"pagopa-notifications-service","log.level":"info","message":"Message sent with ID <01150195f16635bf-e0365832-748d-44e5-ac70-1be30823c472-000000@eu-south-1.amazonses.com>","service.environment":"dev","service.name":"pagopa-notifications-service","service.version":"1.10.0","span_id":"a3bd93c226e95283","trace_flags":"01","trace_id":"c3175404759045c751d2d3879877ce2d"}
{"@timestamp":"2025-04-01T12:51:06.207Z","ecs.version":"8.10.0","event.dataset":"pagopa-notifications-service","log.level":"info","message":"Using cached template for ko","service.environment":"dev","service.name":"pagopa-notifications-service","service.version":"1.10.0","span_id":"e87607582405e007","trace_flags":"01","trace_id":"c3175404759045c751d2d3879877ce2d"}
{"@timestamp":"2025-04-01T12:51:06.209Z","ecs.version":"8.10.0","event.dataset":"pagopa-notifications-service","log.level":"info","message":"[CLIENT_ECOMMERCE] - Sending email with template ko","service.environment":"dev","service.name":"pagopa-notifications-service","service.version":"1.10.0","span_id":"e87607582405e007","trace_flags":"01","trace_id":"c3175404759045c751d2d3879877ce2d"}
{"@timestamp":"2025-04-01T12:51:06.513Z","ecs.version":"8.10.0","event.dataset":"pagopa-notifications-service","log.level":"info","message":"Message sent with ID <01150195f167cc3f-fe43da07-16a6-4311-96a7-9eede63155de-000000@eu-south-1.amazonses.com>","service.environment":"dev","service.name":"pagopa-notifications-service","service.version":"1.10.0","span_id":"e87607582405e007","trace_flags":"01","trace_id":"c3175404759045c751d2d3879877ce2d"}
{"@timestamp":"2025-04-01T12:55:11.092Z","ecs.version":"8.10.0","event.dataset":"pagopa-notifications-service","log.level":"info","message":"Using cached template for ko","service.environment":"dev","service.name":"pagopa-notifications-service","service.version":"1.10.0","span_id":"d8d95b8fcf9e0060","trace_flags":"01","trace_id":"c3175404759045c751d2d3879877ce2d"}
{"@timestamp":"2025-04-01T12:55:11.093Z","ecs.version":"8.10.0","event.dataset":"pagopa-notifications-service","log.level":"info","message":"[CLIENT_ECOMMERCE] - Sending email with template ko","service.environment":"dev","service.name":"pagopa-notifications-service","service.version":"1.10.0","span_id":"d8d95b8fcf9e0060","trace_flags":"01","trace_id":"c3175404759045c751d2d3879877ce2d"}
{"@timestamp":"2025-04-01T12:55:11.433Z","ecs.version":"8.10.0","event.dataset":"pagopa-notifications-service","log.level":"info","message":"Message sent with ID <01150195f16b88eb-32f0b384-6e7e-4243-983c-60c8f2a07cce-000000@eu-south-1.amazonses.com>","service.environment":"dev","service.name":"pagopa-notifications-service","service.version":"1.10.0","span_id":"d8d95b8fcf9e0060","trace_flags":"01","trace_id":"c3175404759045c751d2d3879877ce2d"}
{"@timestamp":"2025-04-01T12:59:31.087Z","ecs.version":"8.10.0","event.dataset":"pagopa-notifications-service","log.level":"info","message":"Using cached template for success","service.environment":"dev","service.name":"pagopa-notifications-service","service.version":"1.10.0","span_id":"6bff5f736c1417b2","trace_flags":"01","trace_id":"c3175404759045c751d2d3879877ce2d"}
{"@timestamp":"2025-04-01T12:59:31.090Z","ecs.version":"8.10.0","event.dataset":"pagopa-notifications-service","log.level":"info","message":"[CLIENT_ECOMMERCE] - Sending email with template success","service.environment":"dev","service.name":"pagopa-notifications-service","service.version":"1.10.0","span_id":"6bff5f736c1417b2","trace_flags":"01","trace_id":"c3175404759045c751d2d3879877ce2d"}
{"@timestamp":"2025-04-01T12:59:31.335Z","ecs.version":"8.10.0","event.dataset":"pagopa-notifications-service","log.level":"info","message":"Message sent with ID <01150195f16f803b-a1ed4d36-1850-4cef-8a2d-4d939531ad73-000000@eu-south-1.amazonses.com>","service.environment":"dev","service.name":"pagopa-notifications-service","service.version":"1.10.0","span_id":"6bff5f736c1417b2","trace_flags":"01","trace_id":"c3175404759045c751d2d3879877ce2d"}
```

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
