### PR TITLE
fix(templates): [CHK-4886] replace linked selfcare css with inline one

### DIFF
--- a/src/templates/ko/ko.template.html
+++ b/src/templates/ko/ko.template.html
@@ -60,42 +60,42 @@
         font-family: "Titillium Web";
         font-display: swap;
         font-weight: 400;
-        src: url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Regular.woff2")
+        src: url("https://assets.cdn.platform.pagopa.it/font/Titillium_Web/TitilliumWeb-Regular.woff2")
             format("woff2"),
-          url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Regular.woff")
+          url("https://assets.cdn.platform.pagopa.it/font/Titillium_Web/TitilliumWeb-Regular.woff")
             format("woff"),
-          url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Regular.ttf")
+          url("https://assets.cdn.platform.pagopa.it/font/Titillium_Web/TitilliumWeb-Regular.ttf")
             format("truetype");
       }
       @font-face {
         font-family: "Titillium Web";
         font-weight: 600;
         font-display: swap;
-        src: url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-SemiBold.woff2")
+        src: url("https://assets.cdn.platform.pagopa.it/font/Titillium_Web/TitilliumWeb-SemiBold.woff2")
             format("woff2"),
-          url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-SemiBold.woff")
+          url("https://assets.cdn.platform.pagopa.it/font/Titillium_Web/TitilliumWeb-SemiBold.woff")
             format("woff"),
-          url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-SemiBold.ttf")
+          url("https://assets.cdn.platform.pagopa.it/font/Titillium_Web/TitilliumWeb-SemiBold.ttf")
             format("truetype");
       }
       @font-face {
         font-family: "Titillium Web";
         font-display: swap;
         font-weight: 700;
-        src: url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Bold.woff2")
+        src: url("https://assets.cdn.platform.pagopa.it/font/Titillium_Web/TitilliumWeb-Bold.woff2")
             format("woff2"),
-          url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Bold.woff")
+          url("https://assets.cdn.platform.pagopa.it/font/Titillium_Web/TitilliumWeb-Bold.woff")
             format("woff"),
-          url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Bold.ttf")
+          url("https://assets.cdn.platform.pagopa.it/font/Titillium_Web/TitilliumWeb-Bold.ttf")
             format("truetype");
       }
       @font-face {
         font-family: "Titillium Sans Pro";
         font-display: swap;
         font-weight: 400; /* Regular weight */
-        src: url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-Regular.woff2")
+        src: url("https://assets.cdn.platform.pagopa.it/font/Titillium_Sans_Pro/TitilliumSansPro-Regular.woff2")
             format("woff2"),
-          url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-Regular.woff")
+          url("https://assets.cdn.platform.pagopa.it/font/Titillium_Sans_Pro/TitilliumSansPro-Regular.woff")
             format("woff");
       }
 
@@ -103,9 +103,9 @@
         font-family: "Titillium Sans Pro";
         font-display: swap;
         font-weight: 600; /* SemiBold weight */
-        src: url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-SemiBold.woff2")
+        src: url("https://assets.cdn.platform.pagopa.it/font/Titillium_Sans_Pro/TitilliumSansPro-Semibold.woff2")
             format("woff2"),
-          url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-SemiBold.woff")
+          url("https://assets.cdn.platform.pagopa.it/font/Titillium_Sans_Pro/TitilliumSansPro-Semibold.woff")
             format("woff");
       }
 
@@ -113,9 +113,9 @@
         font-family: "Titillium Sans Pro";
         font-display: swap;
         font-weight: 700; /* Bold weight */
-        src: url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-Bold.woff2")
+        src: url("https://assets.cdn.platform.pagopa.it/font/Titillium_Sans_Pro/TitilliumSansPro-Bold.woff2")
             format("woff2"),
-          url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-Bold.woff")
+          url("https://assets.cdn.platform.pagopa.it/font/Titillium_Sans_Pro/TitilliumSansPro-Bold.woff")
             format("woff");
       }
     </style>

--- a/src/templates/ko/ko.template.html
+++ b/src/templates/ko/ko.template.html
@@ -55,9 +55,69 @@
     <![endif]-->
 
     <!--[if !mso]><!-->
-    <link href="https://selfcare.pagopa.it/assets/font/selfhostedfonts.css" rel="stylesheet" type="text/css" />
     <style type="text/css">
-      @import url(https://selfcare.pagopa.it/assets/font/selfhostedfonts.css);
+      @font-face {
+        font-family: "Titillium Web";
+        font-display: swap;
+        font-weight: 400;
+        src: url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Regular.woff2")
+            format("woff2"),
+          url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Regular.woff")
+            format("woff"),
+          url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Regular.ttf")
+            format("truetype");
+      }
+      @font-face {
+        font-family: "Titillium Web";
+        font-weight: 600;
+        font-display: swap;
+        src: url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-SemiBold.woff2")
+            format("woff2"),
+          url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-SemiBold.woff")
+            format("woff"),
+          url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-SemiBold.ttf")
+            format("truetype");
+      }
+      @font-face {
+        font-family: "Titillium Web";
+        font-display: swap;
+        font-weight: 700;
+        src: url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Bold.woff2")
+            format("woff2"),
+          url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Bold.woff")
+            format("woff"),
+          url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Bold.ttf")
+            format("truetype");
+      }
+      @font-face {
+        font-family: "Titillium Sans Pro";
+        font-display: swap;
+        font-weight: 400; /* Regular weight */
+        src: url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-Regular.woff2")
+            format("woff2"),
+          url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-Regular.woff")
+            format("woff");
+      }
+
+      @font-face {
+        font-family: "Titillium Sans Pro";
+        font-display: swap;
+        font-weight: 600; /* SemiBold weight */
+        src: url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-SemiBold.woff2")
+            format("woff2"),
+          url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-SemiBold.woff")
+            format("woff");
+      }
+
+      @font-face {
+        font-family: "Titillium Sans Pro";
+        font-display: swap;
+        font-weight: 700; /* Bold weight */
+        src: url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-Bold.woff2")
+            format("woff2"),
+          url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-Bold.woff")
+            format("woff");
+      }
     </style>
     <!--<![endif]-->
 

--- a/src/templates/success/success.template.html
+++ b/src/templates/success/success.template.html
@@ -60,42 +60,42 @@
         font-family: "Titillium Web";
         font-display: swap;
         font-weight: 400;
-        src: url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Regular.woff2")
+        src: url("https://assets.cdn.platform.pagopa.it/font/Titillium_Web/TitilliumWeb-Regular.woff2")
             format("woff2"),
-          url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Regular.woff")
+          url("https://assets.cdn.platform.pagopa.it/font/Titillium_Web/TitilliumWeb-Regular.woff")
             format("woff"),
-          url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Regular.ttf")
+          url("https://assets.cdn.platform.pagopa.it/font/Titillium_Web/TitilliumWeb-Regular.ttf")
             format("truetype");
       }
       @font-face {
         font-family: "Titillium Web";
         font-weight: 600;
         font-display: swap;
-        src: url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-SemiBold.woff2")
+        src: url("https://assets.cdn.platform.pagopa.it/font/Titillium_Web/TitilliumWeb-SemiBold.woff2")
             format("woff2"),
-          url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-SemiBold.woff")
+          url("https://assets.cdn.platform.pagopa.it/font/Titillium_Web/TitilliumWeb-SemiBold.woff")
             format("woff"),
-          url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-SemiBold.ttf")
+          url("https://assets.cdn.platform.pagopa.it/font/Titillium_Web/TitilliumWeb-SemiBold.ttf")
             format("truetype");
       }
       @font-face {
         font-family: "Titillium Web";
         font-display: swap;
         font-weight: 700;
-        src: url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Bold.woff2")
+        src: url("https://assets.cdn.platform.pagopa.it/font/Titillium_Web/TitilliumWeb-Bold.woff2")
             format("woff2"),
-          url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Bold.woff")
+          url("https://assets.cdn.platform.pagopa.it/font/Titillium_Web/TitilliumWeb-Bold.woff")
             format("woff"),
-          url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Bold.ttf")
+          url("https://assets.cdn.platform.pagopa.it/font/Titillium_Web/TitilliumWeb-Bold.ttf")
             format("truetype");
       }
       @font-face {
         font-family: "Titillium Sans Pro";
         font-display: swap;
         font-weight: 400; /* Regular weight */
-        src: url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-Regular.woff2")
+        src: url("https://assets.cdn.platform.pagopa.it/font/Titillium_Sans_Pro/TitilliumSansPro-Regular.woff2")
             format("woff2"),
-          url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-Regular.woff")
+          url("https://assets.cdn.platform.pagopa.it/font/Titillium_Sans_Pro/TitilliumSansPro-Regular.woff")
             format("woff");
       }
 
@@ -103,9 +103,9 @@
         font-family: "Titillium Sans Pro";
         font-display: swap;
         font-weight: 600; /* SemiBold weight */
-        src: url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-SemiBold.woff2")
+        src: url("https://assets.cdn.platform.pagopa.it/font/Titillium_Sans_Pro/TitilliumSansPro-Semibold.woff2")
             format("woff2"),
-          url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-SemiBold.woff")
+          url("https://assets.cdn.platform.pagopa.it/font/Titillium_Sans_Pro/TitilliumSansPro-Semibold.woff")
             format("woff");
       }
 
@@ -113,9 +113,9 @@
         font-family: "Titillium Sans Pro";
         font-display: swap;
         font-weight: 700; /* Bold weight */
-        src: url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-Bold.woff2")
+        src: url("https://assets.cdn.platform.pagopa.it/font/Titillium_Sans_Pro/TitilliumSansPro-Bold.woff2")
             format("woff2"),
-          url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-Bold.woff")
+          url("https://assets.cdn.platform.pagopa.it/font/Titillium_Sans_Pro/TitilliumSansPro-Bold.woff")
             format("woff");
       }
     </style>

--- a/src/templates/success/success.template.html
+++ b/src/templates/success/success.template.html
@@ -55,9 +55,69 @@
     <![endif]-->
 
     <!--[if !mso]><!-->
-    <link href="https://selfcare.pagopa.it/assets/font/selfhostedfonts.css" rel="stylesheet" type="text/css" />
     <style type="text/css">
-      @import url(https://selfcare.pagopa.it/assets/font/selfhostedfonts.css);
+      @font-face {
+        font-family: "Titillium Web";
+        font-display: swap;
+        font-weight: 400;
+        src: url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Regular.woff2")
+            format("woff2"),
+          url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Regular.woff")
+            format("woff"),
+          url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Regular.ttf")
+            format("truetype");
+      }
+      @font-face {
+        font-family: "Titillium Web";
+        font-weight: 600;
+        font-display: swap;
+        src: url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-SemiBold.woff2")
+            format("woff2"),
+          url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-SemiBold.woff")
+            format("woff"),
+          url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-SemiBold.ttf")
+            format("truetype");
+      }
+      @font-face {
+        font-family: "Titillium Web";
+        font-display: swap;
+        font-weight: 700;
+        src: url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Bold.woff2")
+            format("woff2"),
+          url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Bold.woff")
+            format("woff"),
+          url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Bold.ttf")
+            format("truetype");
+      }
+      @font-face {
+        font-family: "Titillium Sans Pro";
+        font-display: swap;
+        font-weight: 400; /* Regular weight */
+        src: url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-Regular.woff2")
+            format("woff2"),
+          url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-Regular.woff")
+            format("woff");
+      }
+
+      @font-face {
+        font-family: "Titillium Sans Pro";
+        font-display: swap;
+        font-weight: 600; /* SemiBold weight */
+        src: url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-SemiBold.woff2")
+            format("woff2"),
+          url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-SemiBold.woff")
+            format("woff");
+      }
+
+      @font-face {
+        font-family: "Titillium Sans Pro";
+        font-display: swap;
+        font-weight: 700; /* Bold weight */
+        src: url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-Bold.woff2")
+            format("woff2"),
+          url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-Bold.woff")
+            format("woff");
+      }
     </style>
     <!--<![endif]-->
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
- Replaced linked Selfcare CSS with inline one
- Updated underlying CSS to reference the pagopa platform CDN

#### Motivation and Context
The goal is to fix a vulnerability identified by the VA/PT performed on eCommerce and Checkout. The vulnerability was about two `link` tags, pointing at a CSS file hosted on  _selfcare.pagopa.it_, missing the `integrity` attribute which could have led to various types of attacks (e.g. XSS). 

Since the CSS is not part of the eCommerce domain it was replaced by the inline version of it. Additionally the CSS was updated to reference the font sources from the pagoPA platform CDN instead of the Selfcare one, removing the dependency. The fonts have been added on the CDN in this PR: https://github.com/pagopa/pagopa-platform-cdn-assets/pull/24

#### How Has This Been Tested?
- DEV deploy

#### Screenshots (if appropriate):

DEV email: 

<img width="674" height="971" alt="image" src="https://github.com/user-attachments/assets/da643ab8-3b90-4c0b-93f3-be619c5a81b4" />

<img width="674" height="677" alt="image" src="https://github.com/user-attachments/assets/fce2ad47-3109-4b2b-bd43-8e3b9e5ec542" />



#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
